### PR TITLE
Add ARM64 to Docker Build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,10 +1,13 @@
 name: Publish Docker image
 
 on:
+  release:
+    types: [published, edited]  
   push:
     branches: [ "main" ]   # or "master", or whatever branch you want
     paths-ignore:
       - 'README.md'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -15,9 +18,34 @@ jobs:
       packages: write   # needed for GHCR
 
     steps:
+      - name: Debug Variables
+        run: |
+            echo "github.event_name: ${{ github.event_name }}"
+            echo "github.ref_name: ${{ github.ref_name }}"
+            echo "github.actor: ${{ github.actor  }}"
+            echo "github.repository_owner: ${{ github.repository_owner }}"
+            echo "github.repository: ${{ github.repository }}"
+      
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=true
+          tags: |
+            type=sha
+            type=semver,pattern={{version}}
+        
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -29,7 +57,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: ./Dockerfile
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:latest
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.sha }}
+          platforms: linux/amd64,linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing Docker images to improve its flexibility, support multi-platform builds, and enhance maintainability. The workflow now triggers on releases and manual dispatch, includes debugging output, and uses Docker Buildx for building images for multiple architectures with improved tagging and metadata.

For every push to main, including releases, it will generate a sha tag and also assign it the latest tag.
For a release, it will also create a tag for the semver version as well.
Can also be run manually.

**Workflow triggers and debugging:**
* The workflow now triggers on release events (published, edited) and can be manually dispatched, in addition to pushes to `main`. Debugging steps have been added to print important GitHub context variables for easier troubleshooting. [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R4-R10) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R21-R48)

**Docker build enhancements:**
* Added steps to set up QEMU and Docker Buildx, enabling multi-platform builds (linux/amd64, linux/arm64). The workflow now uses the Docker metadata action to automatically generate tags and labels, and the build step references these outputs for tagging and labeling images. [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R21-R48) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R60-R64)