### PR TITLE
Add caching and refine tags for docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,9 @@ on:
     branches: [ "main" ]   # or "master", or whatever branch you want
     paths-ignore:
       - 'README.md'
+      - 'docs/**'
+      - 'images/**'
+      - 'tests/**'
   workflow_dispatch:
 
 jobs:
@@ -41,11 +44,13 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           flavor: |
-            latest=true
+            latest=false
           tags: |
-            type=sha
-            type=semver,pattern={{version}}
-        
+            type=semver,pattern={{version}},priority=1000
+            type=ref,event=branch,enable={{is_not_default_branch}},priority=900
+            type=sha,prefix=,format=long,priority=200
+            type=raw,value=latest,enable={{is_default_branch}},priority=100
+          
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,3 +62,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: |
+            type=gha
+            type=gha,scope=main
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Sorry for the quick follow-up PR, but there's a couple of tweaks to the docker build workflow I think will help

- Add caching for the docker builds. Will significantly speed up future builds, especially for only small changes done close together.
- Refine the docker tags

| Trigger | Docker Tags |
| --- | --- |
| Release | - semver version<br/>- latest<br/>- sha |
| Push to main | - latest<br/>- sha |
| Manual run via workflow_dispatch on main | - latest<br/>- sha |
| Manual run via workflow_dispatch on a different branch | - branch name<br/>- sha |

**Workflow trigger improvements:**

* The workflow will now ignore changes in the `docs/**`, `images/**`, and `tests/**` directories, in addition to `README.md`, reducing unnecessary workflow runs.

**Docker image tagging strategy:**

* The `latest` tag is now only applied when building from the default branch, and other tags are prioritized and refined for clarity (e.g., semver, branch, SHA), giving more control over which tags are published and when.

**Build caching enhancements:**

* Docker build caching is enabled using GitHub Actions cache (`type=gha`), which should speed up subsequent builds by reusing layers from previous runs.