### PR TITLE
Add HTTPS support for external integrations

### DIFF
--- a/backend/audiobookrequest_integration.py
+++ b/backend/audiobookrequest_integration.py
@@ -17,7 +17,6 @@ from typing import Any
 import aiohttp
 
 from backend.url_builder import build_service_url
-
 from backend.utils import handle_http_error
 
 _logger = logging.getLogger(__name__)

--- a/backend/audiobookrequest_integration.py
+++ b/backend/audiobookrequest_integration.py
@@ -16,6 +16,8 @@ from typing import Any
 
 import aiohttp
 
+from backend.url_builder import build_service_url
+
 from backend.utils import handle_http_error
 
 _logger = logging.getLogger(__name__)
@@ -38,7 +40,7 @@ async def test_audiobookrequest_connection(host: str, port: int, api_key: str) -
             - success: bool
             - message: str
     """
-    url = f"http://{host}:{port}/api/indexers/configurations"
+    url = build_service_url(host, port, "/api/indexers/configurations")
     headers = {"Authorization": f"Bearer {api_key}", "accept": "application/json"}
 
     try:
@@ -90,7 +92,7 @@ async def sync_mam_id_to_audiobookrequest(
             - message: str (if success)
             - error: str (if failure)
     """
-    url = f"http://{host}:{port}/api/indexers/{_INDEXER_NAME}"
+    url = build_service_url(host, port, f"/api/indexers/{_INDEXER_NAME}")
     headers = {
         "Authorization": f"Bearer {api_key}",
         "accept": "application/json",

--- a/backend/autobrr_integration.py
+++ b/backend/autobrr_integration.py
@@ -16,6 +16,8 @@ from typing import Any
 
 import aiohttp
 
+from backend.url_builder import build_service_url
+
 from backend.utils import handle_http_error
 
 _logger = logging.getLogger(__name__)
@@ -38,7 +40,7 @@ async def test_autobrr_connection(host: str, port: int, api_key: str) -> dict[st
             - success: bool
             - message: str
     """
-    url = f"http://{host}:{port}/api/indexer"
+    url = build_service_url(host, port, "/api/indexer")
     headers = {"X-API-Token": api_key}
 
     try:
@@ -100,7 +102,7 @@ async def sync_mam_id_to_autobrr(
             - error: str (if failure)
     """
     headers = {"X-API-Token": api_key, "Content-Type": "application/json"}
-    list_url = f"http://{host}:{port}/api/indexer"
+    list_url = build_service_url(host, port, "/api/indexer")
 
     try:
         # First, get the list of indexers to find MAM indexer ID
@@ -126,7 +128,7 @@ async def sync_mam_id_to_autobrr(
             indexer_id = mam_indexer["id"]
 
             # Get full indexer details
-            get_url = f"http://{host}:{port}/api/indexer/{indexer_id}"
+            get_url = build_service_url(host, port, f"/api/indexer/{indexer_id}")
             async with session.get(get_url, headers=headers, timeout=_TIMEOUT) as response:
                 if response.status != 200:
                     return handle_http_error(response.status, await response.text(), "MyAnonamouse")
@@ -139,7 +141,7 @@ async def sync_mam_id_to_autobrr(
             indexer_data["settings"]["cookie"] = f"mam_id={new_mam_id}"
 
             # Send PUT request to update indexer
-            put_url = f"http://{host}:{port}/api/indexer/{indexer_id}"
+            put_url = build_service_url(host, port, f"/api/indexer/{indexer_id}")
             async with session.put(
                 put_url, headers=headers, json=indexer_data, timeout=_TIMEOUT
             ) as response:

--- a/backend/autobrr_integration.py
+++ b/backend/autobrr_integration.py
@@ -17,7 +17,6 @@ from typing import Any
 import aiohttp
 
 from backend.url_builder import build_service_url
-
 from backend.utils import handle_http_error
 
 _logger = logging.getLogger(__name__)

--- a/backend/chaptarr_integration.py
+++ b/backend/chaptarr_integration.py
@@ -17,13 +17,15 @@ from typing import Any
 
 import aiohttp
 
+from backend.url_builder import build_service_url
+
 _logger = logging.getLogger(__name__)
 _TIMEOUT = aiohttp.ClientTimeout(total=10)
 
 
 async def test_chaptarr_connection(host: str, port: int, api_key: str) -> dict[str, Any]:
     """Test connection to Chaptarr and return indexer count."""
-    url = f"http://{host}:{port}/api/v1/indexer"
+    url = build_service_url(host, port, "/api/v1/indexer")
     headers = {"X-Api-Key": api_key}
 
     try:
@@ -66,7 +68,7 @@ async def find_mam_indexer_id(host: str, port: int, api_key: str) -> dict[str, A
             - indexer_id: int (if found)
             - message: str
     """
-    url = f"http://{host}:{port}/api/v1/indexer"
+    url = build_service_url(host, port, "/api/v1/indexer")
     headers = {"X-Api-Key": api_key}
 
     try:
@@ -123,7 +125,7 @@ async def get_indexer_config(host: str, port: int, api_key: str, indexer_id: int
             - config: dict (if successful)
             - message: str
     """
-    url = f"http://{host}:{port}/api/v1/indexer/{indexer_id}"
+    url = build_service_url(host, port, f"/api/v1/indexer/{indexer_id}")
     headers = {"X-Api-Key": api_key}
 
     try:
@@ -199,7 +201,7 @@ async def update_mam_id_in_chaptarr(
         }
 
     # Step 3: PUT updated config with forceSave=true
-    url = f"http://{host}:{port}/api/v1/indexer/{indexer_id}?forceSave=true"
+    url = build_service_url(host, port, f"/api/v1/indexer/{indexer_id}?forceSave=true")
     headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
 
     try:

--- a/backend/jackett_integration.py
+++ b/backend/jackett_integration.py
@@ -18,6 +18,8 @@ from typing import Any
 import aiohttp
 from yarl import URL
 
+from backend.url_builder import build_service_url
+
 _logger = logging.getLogger(__name__)
 _TIMEOUT = aiohttp.ClientTimeout(total=10)
 
@@ -37,8 +39,8 @@ async def jackett_login(host: str, port: int, admin_password: str) -> str | None
     Returns:
         Session cookie string if successful, None otherwise
     """
-    login_url = f"http://{host}:{port}/UI/Login"
-    dashboard_url = f"http://{host}:{port}/UI/Dashboard"
+    login_url = build_service_url(host, port, "/UI/Login")
+    dashboard_url = build_service_url(host, port, "/UI/Dashboard")
 
     try:
         # Create cookie jar with unsafe=True to allow cookies for non-secure HTTP domains
@@ -48,7 +50,7 @@ async def jackett_login(host: str, port: int, admin_password: str) -> str | None
             # Step 1: GET /UI/Login to receive TestCookie and Jackett session cookie
             async with session.get(login_url, allow_redirects=True, timeout=_TIMEOUT) as response:
                 # Get all cookies after visiting login page
-                cookies = session.cookie_jar.filter_cookies(URL(f"http://{host}:{port}"))
+                cookies = session.cookie_jar.filter_cookies(URL(build_service_url(host, port)))
 
                 # Check for required cookies
                 has_test_cookie = any(cookie.key == "TestCookie" for cookie in cookies.values())
@@ -72,7 +74,7 @@ async def jackett_login(host: str, port: int, admin_password: str) -> str | None
                     dashboard_url, data=form_data, allow_redirects=True, timeout=_TIMEOUT
                 ) as response:
                     # Get all cookies after authentication
-                    cookies = session.cookie_jar.filter_cookies(URL(f"http://{host}:{port}"))
+                    cookies = session.cookie_jar.filter_cookies(URL(build_service_url(host, port)))
 
                     # Check for Jackett auth cookie
                     has_jackett_cookie = any(cookie.key == "Jackett" for cookie in cookies.values())
@@ -98,7 +100,7 @@ async def jackett_login(host: str, port: int, admin_password: str) -> str | None
                     return None
 
             # Should not reach here, but return cookies we have
-            cookies = session.cookie_jar.filter_cookies(URL(f"http://{host}:{port}"))
+            cookies = session.cookie_jar.filter_cookies(URL(build_service_url(host, port)))
             if cookies:
                 return "; ".join([f"{k}={v.value}" for k, v in cookies.items()])
 
@@ -135,7 +137,7 @@ async def test_jackett_connection(
             }
 
         # Test API access
-        url = f"http://{host}:{port}/api/v2.0/indexers"
+        url = build_service_url(host, port, "/api/v2.0/indexers")
         headers = {"X-Api-Key": api_key}
         if session_cookie:
             headers["Cookie"] = session_cookie
@@ -205,7 +207,7 @@ async def get_indexer_config(
     Returns:
         List of config fields if successful, None otherwise
     """
-    url = f"http://{host}:{port}/api/v2.0/indexers/{indexer_name}/config"
+    url = build_service_url(host, port, f"/api/v2.0/indexers/{indexer_name}/config")
     headers = {"X-Api-Key": api_key}
     if session_cookie:
         headers["Cookie"] = session_cookie
@@ -253,7 +255,7 @@ async def update_indexer_config(
     Returns:
         True if successful, False otherwise
     """
-    url = f"http://{host}:{port}/api/v2.0/indexers/{indexer_name}/config"
+    url = build_service_url(host, port, f"/api/v2.0/indexers/{indexer_name}/config")
     headers = {
         "X-Api-Key": api_key,
         "Content-Type": "application/json",

--- a/backend/prowlarr_integration.py
+++ b/backend/prowlarr_integration.py
@@ -12,13 +12,15 @@ from typing import Any
 
 import aiohttp
 
+from backend.url_builder import build_service_url
+
 _logger = logging.getLogger(__name__)
 _TIMEOUT = aiohttp.ClientTimeout(total=10)
 
 
 async def test_prowlarr_connection(host: str, port: int, api_key: str) -> dict[str, Any]:
     """Test connection to Prowlarr and return indexer count."""
-    url = f"http://{host}:{port}/api/v1/indexer"
+    url = build_service_url(host, port, "/api/v1/indexer")
     headers = {"X-Api-Key": api_key}
 
     try:
@@ -60,7 +62,7 @@ async def find_mam_indexer_id(host: str, port: int, api_key: str) -> dict[str, A
             - indexer_id: int (if found)
             - message: str
     """
-    url = f"http://{host}:{port}/api/v1/indexer"
+    url = build_service_url(host, port, "/api/v1/indexer")
     headers = {"X-Api-Key": api_key}
 
     try:
@@ -114,7 +116,7 @@ async def get_indexer_config(host: str, port: int, api_key: str, indexer_id: int
             - config: dict (if successful)
             - message: str
     """
-    url = f"http://{host}:{port}/api/v1/indexer/{indexer_id}"
+    url = build_service_url(host, port, f"/api/v1/indexer/{indexer_id}")
     headers = {"X-Api-Key": api_key}
 
     try:
@@ -189,7 +191,7 @@ async def update_mam_id_in_prowlarr(
         }
 
     # Step 3: PUT updated config
-    url = f"http://{host}:{port}/api/v1/indexer/{indexer_id}"
+    url = build_service_url(host, port, f"/api/v1/indexer/{indexer_id}")
     headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
 
     try:

--- a/backend/url_builder.py
+++ b/backend/url_builder.py
@@ -1,0 +1,30 @@
+"""Utilities for building service URLs from UI host and port fields."""
+
+from urllib.parse import urlparse
+
+
+def build_service_url(host: str, port: int | str | None, path: str = "") -> str:
+    """Build a service URL from host, port, and path.
+
+    Supports both legacy configuration values, such as:
+        host=service.example.com, port=8080
+
+    and scheme-aware values, such as:
+        host=https://service.example.com, port=443
+
+    If host already includes http:// or https://, the scheme is honored.
+    Otherwise, https is inferred for port 443 and http for all other ports.
+    """
+    host = (host or "").strip().rstrip("/")
+    parsed = urlparse(host)
+
+    if parsed.scheme in {"http", "https"}:
+        base = host
+        if port and parsed.port is None and int(port) not in {80, 443}:
+            base = f"{base}:{int(port)}"
+    else:
+        port_int = int(port or 80)
+        scheme = "https" if port_int == 443 else "http"
+        base = f"{scheme}://{host}:{port_int}"
+
+    return f"{base}{path}"

--- a/backend/url_builder.py
+++ b/backend/url_builder.py
@@ -16,14 +16,18 @@ def build_service_url(host: str, port: int | str | None, path: str = "") -> str:
     Otherwise, https is inferred for port 443 and http for all other ports.
     """
     host = (host or "").strip().rstrip("/")
+    if not host:
+        raise ValueError("Host is required")
+
     parsed = urlparse(host)
 
     if parsed.scheme in {"http", "https"}:
         base = host
-        if port and parsed.port is None and int(port) not in {80, 443}:
-            base = f"{base}:{int(port)}"
     else:
-        port_int = int(port or 80)
+        if port is None or str(port).strip() == "":
+            raise ValueError("Port is required when host does not include a scheme")
+
+        port_int = int(port)
         scheme = "https" if port_int == 443 else "http"
         base = f"{scheme}://{host}:{port_int}"
 


### PR DESCRIPTION
## Summary

Adds HTTPS-aware URL handling for external service integrations.

Previously integrations hardcoded:

python http://{host}:{port} 

which caused failures behind HTTPS reverse proxies and redirects.

This patch adds a shared URL builder helper and updates integrations to support:

- host + port legacy configuration
- Explicit https:// host entries
- Automatic HTTPS selection for port 443

## Updated integrations

- AudioBookRequest
- Autobrr
- Prowlarr
- Jackett
- Chaptarr

## Validation

- python3 -m py_compile backend/*.py
- git diff --check
- Manual validation against Traefik reverse proxy deployments

## Tested

- Prowlarr
- AudioBookRequest
- Autobrr

## Untested (but should work)

- Chaptarr
- Jackett