### PR TITLE
feat: make config and log dirs configurable via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ MouseTrap offers three IP monitoring modes to suit different use cases and netwo
 | `IPINFO_TOKEN`      | ipinfo.io API token (recommended)        | None    | Improves IP detection     |
 | `IPDATA_API_KEY`    | ipdata.co API key (optional)             | test    | 1,500 requests/day free   |
 | `LOGLEVEL`          | Backend log level                        | INFO    | DEBUG, INFO, WARNING      |
+| `CONFIG_DIR`        | Settings and session state directory     | /config | Rarely changed; for non-Docker installs |
+| `LOG_DIR`           | Log and UI event log directory           | /app/logs | Rarely changed; for non-Docker installs |
 
 > **Note:** For port monitoring, either mount `/var/run/docker.sock` OR set `DOCKER_HOST` to a Docker Socket Proxy
 > 
@@ -160,6 +162,7 @@ environment:
 - Port Monitoring: `/config/port_monitoring_stacks.yaml` (auto-created/updated)
 - Logs: `/logs` (persisted outside the container)
 - Global options: `config/config.yaml` (auto-created/updated)
+- These locations can be overridden with the `CONFIG_DIR` and `LOG_DIR` environment variables (see Environment Variables).
 
 ---
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -81,7 +81,7 @@ app = FastAPI(title="MouseTrap API")
 
 # Mount static files BEFORE any catch-all routes
 # Serve logs directory as static files for UI event log access
-logs_dir = Path(__file__).resolve().parent.parent / "logs"
+logs_dir = Path(os.environ.get("LOG_DIR", Path(__file__).parent.parent / "logs"))
 if logs_dir.is_dir():
     app.mount("/logs", StaticFiles(directory=str(logs_dir)), name="logs")
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -5,13 +5,14 @@ configuration files, a default global config, and simple helpers used by
 the backend to locate and manage session files.
 """
 
+from os import environ
 from pathlib import Path
 import threading
 from typing import Any
 
 import yaml
 
-CONFIG_DIR = Path("/config")
+CONFIG_DIR = Path(environ.get("CONFIG_DIR", "/config"))
 CONFIG_PATH = CONFIG_DIR / "config.yaml"
 _LOCK = threading.Lock()
 

--- a/backend/event_log.py
+++ b/backend/event_log.py
@@ -5,6 +5,7 @@ is used by the backend to record UI events for debugging and auditing.
 
 import json
 import logging
+from os import environ
 from pathlib import Path
 from threading import Lock
 from typing import Any
@@ -12,8 +13,8 @@ from typing import Any
 from backend.utils_redact import redact_sensitive
 
 _logger: logging.Logger = logging.getLogger(__name__)
-_ui_event_log_path = Path(__file__).parent.parent / "logs" / "ui_event_log.json"
-_ui_event_log_dir = _ui_event_log_path.parent
+_ui_event_log_dir = Path(environ.get("LOG_DIR", Path(__file__).parent.parent / "logs"))
+_ui_event_log_path = _ui_event_log_dir / "ui_event_log.json"
 _ui_event_log_lock = Lock()
 
 # Expose the log path for use in app.py


### PR DESCRIPTION
`CONFIG_DIR` and `LOG_DIR` now honor environment variables, defaulting to the current `/config` and bundled `logs/`, matching the existing pattern used by `NOTIFY_CONFIG_PATH`/`PORT_MONITOR_CONFIG_PATH`. This lets MouseTrap run outside the default Docker layout (rootless / FHS / systemd) where those paths aren't writable; defaults are unchanged, so existing Docker deployments are unaffected.