### PR TITLE
fix: honor CONFIG_DIR for all config files (drop hardcoded /config)

### DIFF
--- a/backend/last_session_api.py
+++ b/backend/last_session_api.py
@@ -7,14 +7,15 @@ This module exposes two endpoints under `/last_session`:
 Persistence is a simple YAML file located at `LAST_SESSION_FILE`.
 """
 
-from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 import yaml
 
+from backend.config import CONFIG_DIR
+
 router = APIRouter()
-LAST_SESSION_FILE = Path("/config/last_session.yaml")
+LAST_SESSION_FILE = CONFIG_DIR / "last_session.yaml"
 
 
 def read_last_session() -> str | None:

--- a/backend/notifications_backend.py
+++ b/backend/notifications_backend.py
@@ -17,9 +17,11 @@ from typing import Any
 import aiohttp
 import yaml
 
+from backend.config import CONFIG_DIR
+
 _logger: logging.Logger = logging.getLogger(__name__)
-# Notification config (could be loaded from YAML or env)
-NOTIFY_CONFIG_PATH = os.environ.get("NOTIFY_CONFIG_PATH", "/config/notify.yaml")
+# Notification config: explicit NOTIFY_CONFIG_PATH override, else derived from CONFIG_DIR
+NOTIFY_CONFIG_PATH = os.environ.get("NOTIFY_CONFIG_PATH") or CONFIG_DIR / "notify.yaml"
 
 
 async def send_webhook_notification(url: str, payload: dict, discord: bool = False) -> bool:

--- a/backend/port_monitor.py
+++ b/backend/port_monitor.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import yaml
 
+from backend.config import CONFIG_DIR
 from backend.event_log import append_ui_event_log
 from backend.notifications_backend import notify_event
 
@@ -27,7 +28,7 @@ except ImportError:
 
 _logger: logging.Logger = logging.getLogger(__name__)
 PORT_MONITOR_CONFIG_PATH = Path(
-    os.environ.get("PORT_MONITOR_CONFIG_PATH", "/config/port_monitoring_stacks.yaml")
+    os.environ.get("PORT_MONITOR_CONFIG_PATH") or CONFIG_DIR / "port_monitoring_stacks.yaml"
 )
 
 

--- a/backend/proxy_config.py
+++ b/backend/proxy_config.py
@@ -13,7 +13,9 @@ from typing import Any
 
 import yaml
 
-PROXIES_PATH = "/config/proxies.yaml"
+from backend.config import CONFIG_DIR
+
+PROXIES_PATH = CONFIG_DIR / "proxies.yaml"
 _LOCK = threading.Lock()
 _logger: logging.Logger = logging.getLogger(__name__)
 _last_resolve_log_time: dict[str, float] = {}


### PR DESCRIPTION
#58 made the config and log directories configurable via `CONFIG_DIR` / `LOG_DIR`, but several modules still hardcode `/config`, so pointing `CONFIG_DIR` at a non-default mount silently leaves those files behind in `/config`.

The offenders:

- `proxy_config.py` — `PROXIES_PATH = "/config/proxies.yaml"`
- `last_session_api.py` — `LAST_SESSION_FILE = Path("/config/last_session.yaml")`
- `notifications_backend.py` — `NOTIFY_CONFIG_PATH` default `"/config/notify.yaml"`
- `port_monitor.py` — `PORT_MONITOR_CONFIG_PATH` default `"/config/port_monitoring_stacks.yaml"`

This derives each from `config.CONFIG_DIR` instead. The explicit override env vars (`NOTIFY_CONFIG_PATH`, `PORT_MONITOR_CONFIG_PATH`) are preserved; only their defaults now follow `CONFIG_DIR`. `config.py` imports nothing from the package, so there's no import cycle, and no new dependencies are added.

With this, mounting config at e.g. `/srv/app/config` and setting `CONFIG_DIR` puts every config file there, not just the session YAMLs.