### PR TITLE
fix: avoid crash when VIP automation weeks is "max" with min-points guardrail

### DIFF
--- a/backend/automation.py
+++ b/backend/automation.py
@@ -335,7 +335,9 @@ async def vip_automation_job() -> None:
             )
             if enforce_min_points_guardrail and session_min_points is not None:
                 purchase_cost = (
-                    _VIP_POINTS_COST.get(int(weeks)) if int(weeks) in _VIP_POINTS_COST else None
+                    None
+                    if str(weeks).lower() in ("max", "90")
+                    else _VIP_POINTS_COST.get(int(weeks))
                 )
                 if purchase_cost is not None and int(points) - purchase_cost < int(
                     session_min_points


### PR DESCRIPTION
In `vip_automation_job`, when `enforce_min_points_guardrail` is enabled the purchase cost is computed as `_VIP_POINTS_COST.get(int(weeks))`. For a max-duration VIP purchase (`weeks` is `"max"` or `"90"`), `int("max")` raises `ValueError` and the automation job crashes before it can run.

Max/90-week VIP has a variable point cost that the fixed-cost guardrail can't evaluate anyway, so this skips the cost lookup for those values (leaving `purchase_cost = None`, which the existing `if purchase_cost is not None` check already handles). This matches how the rest of the job treats the max case.