### PR TITLE
fix: resolve proxy by label truthiness so an empty label falls through

### DIFF
--- a/backend/proxy_config.py
+++ b/backend/proxy_config.py
@@ -44,7 +44,7 @@ def resolve_proxy_from_session_cfg(cfg: dict[str, Any]) -> dict[str, Any] | None
     if now - last >= _resolve_log_min_interval:
         _logger.debug("[resolve_proxy_from_session_cfg] Input cfg proxy: %s", proxy)
         _last_resolve_log_time[log_key] = now
-    if isinstance(proxy, dict) and "label" in proxy:
+    if isinstance(proxy, dict) and proxy.get("label"):
         proxies = load_proxies()
         label = proxy["label"]
         resolved = proxies.get(label)


### PR DESCRIPTION
`resolve_proxy_from_session_cfg` is inconsistent: it builds its debug log key from `proxy.get("label")` (truthiness) but resolves from `"label" in proxy` (key presence). A proxy config carrying an empty label, `{"label": ""}`, therefore enters the label branch, looks up `""` in `proxies.yaml`, gets `None`, and returns no proxy, instead of falling through to the inline/host branch.

This gates resolution on `proxy.get("label")` as well, so an empty label is treated as "no label" consistently.