### PR TITLE
fix: use consistent check_freq default (5) in the cached status path

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1129,7 +1129,7 @@ async def api_status(label: str = Query(None), force: int = Query(0)) -> dict[st
     # If we have cached data and not forcing, use it and calculate next_check_time
     if not force and status:
         # Use cached data with calculated timing
-        check_freq_minutes = cfg.get("check_freq", 15)
+        check_freq_minutes = cfg.get("check_freq", 5)
         if last_check_time:
             try:
                 last_check_dt = datetime.fromisoformat(last_check_time)


### PR DESCRIPTION
`/api/status` computes `next_check_time` in two places: a cached path and a fresh-check path. When a session has no explicit `check_freq`, the cached path defaults to `15` minutes while the fresh path defaults to `5`, so the displayed next-check time differs depending on which path served the response. The frontend also assumes `5` (`data.n || 5`).

This aligns the cached path's default to `5`.