### PR TITLE
perf: store the UI event log in SQLite and retire the logs directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ services:
       - PGID=1000        # Your host group ID
     volumes:
       - ./config:/config # Persistent settings
-      - ./logs:/app/logs # Logs for troubleshooting
     ports:
       - 39842:39842
 ```
@@ -93,7 +92,6 @@ MouseTrap offers three IP monitoring modes to suit different use cases and netwo
 | `IPDATA_API_KEY`    | ipdata.co API key (optional)             | test    | 1,500 requests/day free   |
 | `LOGLEVEL`          | Backend log level                        | INFO    | DEBUG, INFO, WARNING      |
 | `CONFIG_DIR`        | Settings and session state directory     | /config | Rarely changed; for non-Docker installs |
-| `LOG_DIR`           | Log and UI event log directory           | /app/logs | Rarely changed; for non-Docker installs |
 
 > **Note:** For port monitoring, either mount `/var/run/docker.sock` OR set `DOCKER_HOST` to a Docker Socket Proxy
 > 
@@ -160,9 +158,8 @@ environment:
 - All settings and state are stored in `/config` (if mapped as a volume)
 - Each session: `config/session-*.yaml` (created via the UI)
 - Port Monitoring: `/config/port_monitoring_stacks.yaml` (auto-created/updated)
-- Logs: `/logs` (persisted outside the container)
 - Global options: `config/config.yaml` (auto-created/updated)
-- These locations can be overridden with the `CONFIG_DIR` and `LOG_DIR` environment variables (see Environment Variables).
+- These locations can be overridden with the `CONFIG_DIR` environment variable (see Environment Variables).
 
 ---
 
@@ -198,7 +195,6 @@ services:
       - DOCKER_HOST=tcp://docker-proxy:2375  # Connect via proxy
     volumes:
       - ./config:/config
-      - ./logs:/app/logs
       # No docker.sock mount needed!
     networks:
       - mousetrap-network
@@ -219,7 +215,6 @@ Add Docker socket access directly:
 ```yaml
 volumes:
   - ./config:/config
-  - ./logs:/app/logs
   - /var/run/docker.sock:/var/run/docker.sock:ro  # Add this line
 ```
 
@@ -378,7 +373,6 @@ services:
       - DOCKER_GID=281 # (Optional) Set to your host's Docker group GID if not 992
     volumes:
       - ./config:/config
-      - ./logs:/app/logs
       - /var/run/docker.sock:/var/run/docker.sock:ro #Optional, for port monitoring support
     # No ports here! All traffic is routed through gluetun
 ```
@@ -421,7 +415,6 @@ services:
       - DOCKER_GID=281 # (Optional) Set to your host's Docker group GID if not 992
     volumes:
       - ./config:/config
-      - ./logs:/app/logs 
       - /var/run/docker.sock:/var/run/docker.sock:ro #Optional, for port monitoring support
     ports:
       - 39842:39842
@@ -451,7 +444,6 @@ services:
 #      - IPINFO_TOKEN=your_token_here # Optional
     volumes:
       - ../config:/config # Persist configs (use absolute if needed, e.g., /mnt/user/appdata/mousetrap/config)
-      - ../logs:/app/logs # Persist logs
       - /var/run/docker.sock:/var/run/docker.sock
     restart: unless-stopped
 ```
@@ -460,7 +452,6 @@ Adjust paths and environment variables as needed for your Unraid setup.
 
 **Notes:**
 - The `/var/run/docker.sock` mount is only required if you want to enable the Port Monitoring feature. Without it, all other features will work normally.
-- The `./logs:/app/logs` volume is recommended to persist logs outside the container. This allows you to view logs even if the container is removed or recreated.
 - In HTTP proxy mode, enter your proxy credentials in each session's proxy config in the MouseTrap UI that you want to route through the proxy's connection.
 - For other VPN containers see their docs for enabling Privoxy or HTTP proxy and adjust the Compose file accordingly.
 - In VPN mode, only the VPN container should expose ports. In non-VPN/proxy mode, expose 39842 on the `mousetrap` service.

--- a/backend/app.py
+++ b/backend/app.py
@@ -80,11 +80,6 @@ _logger: logging.Logger = logging.getLogger(__name__)
 app = FastAPI(title="MouseTrap API")
 
 # Mount static files BEFORE any catch-all routes
-# Serve logs directory as static files for UI event log access
-logs_dir = Path(os.environ.get("LOG_DIR", Path(__file__).parent.parent / "logs"))
-if logs_dir.is_dir():
-    app.mount("/logs", StaticFiles(directory=str(logs_dir)), name="logs")
-
 if ASSETS_DIR.is_dir():
     app.mount("/assets", StaticFiles(directory=str(ASSETS_DIR)), name="assets")
 else:

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,55 @@
+"""SQLite-backed persistence for the backend.
+
+Owns the process-wide connection and schema and currently backs the UI event
+log. It is structured to grow additional tables (runtime state, etc.) over
+time. Every caller goes through :func:`connection`, which serializes access to
+the single shared connection with a lock, so it is safe to use from the FastAPI
+threadpool and worker threads alike.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from functools import cache
+import sqlite3
+from threading import Lock
+
+from backend.config import CONFIG_DIR
+
+DB_PATH = CONFIG_DIR / "mousetrap.db"
+
+_lock = Lock()
+
+
+def _init(conn: sqlite3.Connection) -> None:
+    """Create tables and indexes if they do not already exist."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS events (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            label      TEXT,
+            event_type TEXT,
+            ts         TEXT,
+            data       TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_events_label ON events (label)")
+    conn.commit()
+
+
+@cache
+def _get_conn() -> sqlite3.Connection:
+    """Open the process-wide connection once and apply the schema."""
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    _init(conn)
+    return conn
+
+
+@contextmanager
+def connection() -> Iterator[sqlite3.Connection]:
+    """Yield the process-wide SQLite connection under a lock (created lazily, once)."""
+    with _lock:
+        yield _get_conn()

--- a/backend/event_log.py
+++ b/backend/event_log.py
@@ -1,88 +1,66 @@
-"""Manage a persistent JSON UI event log with helpers to append, read, and clear
-events; sensitive fields are redacted before being written to disk. This module
-is used by the backend to record UI events for debugging and auditing.
+"""Persistent UI event log, backed by the shared SQLite database.
+
+Records UI events (session checks, IP changes, purchases, port-monitor status,
+integration syncs, etc.) for the frontend activity feed. Sensitive fields are
+redacted before storage, and the log is capped at the newest ``_MAX_EVENTS``.
 """
 
 import json
 import logging
-from os import environ
-from pathlib import Path
-from threading import Lock
+import sqlite3
 from typing import Any
 
+from backend import db
 from backend.utils_redact import redact_sensitive
 
+_MAX_EVENTS = 1000
 _logger: logging.Logger = logging.getLogger(__name__)
-_ui_event_log_dir = Path(environ.get("LOG_DIR", Path(__file__).parent.parent / "logs"))
-_ui_event_log_path = _ui_event_log_dir / "ui_event_log.json"
-_ui_event_log_lock = Lock()
-
-# Expose the log path for use in app.py
-UI_EVENT_LOG_PATH = _ui_event_log_path
-UI_EVENT_LOG_LOCK = _ui_event_log_lock
-
-
-def _init_ui_event_log() -> None:
-    try:
-        _ui_event_log_dir.mkdir(parents=True, exist_ok=True)
-        if not _ui_event_log_path.exists():
-            with _ui_event_log_path.open("w", encoding="utf-8") as f:
-                json.dump([], f)
-    except Exception as e:
-        _logger.error("[UIEventLog] Failed to initialize event log: %s", e)
-
-
-_init_ui_event_log()
 
 
 def append_ui_event_log(event: dict[str, Any]) -> None:
-    """Append an event (dict) to the persistent UI event log file as a JSON array, with sensitive fields redacted."""
-    _ui_event_log_lock.acquire()
+    """Append a redacted event to the log, keeping only the newest _MAX_EVENTS."""
     try:
-        # Read existing log
-        try:
-            with _ui_event_log_path.open(encoding="utf-8") as f:
-                log = json.load(f)
-        except Exception:
-            log = []
-        redacted_event = redact_sensitive(event)
-        log.append(redacted_event)
-        # Keep log at most 1000 entries
-        if len(log) > 1000:
-            log = log[-1000:]
-        with _ui_event_log_path.open("w", encoding="utf-8") as f:
-            json.dump(log, f, indent=2)
-    except Exception as e:
+        redacted = redact_sensitive(event)
+        with db.connection() as conn:
+            conn.execute(
+                "INSERT INTO events (label, event_type, ts, data) VALUES (?, ?, ?, ?)",
+                (
+                    redacted.get("label"),
+                    redacted.get("event_type"),
+                    redacted.get("timestamp"),
+                    json.dumps(redacted),
+                ),
+            )
+            conn.execute(
+                "DELETE FROM events WHERE id <= (SELECT MAX(id) FROM events) - ?",
+                (_MAX_EVENTS,),
+            )
+            conn.commit()
+    except (TypeError, ValueError, sqlite3.Error) as e:
         _logger.error("[UIEventLog] Failed to append event: %s", e)
-    finally:
-        _ui_event_log_lock.release()
 
 
-def get_ui_event_log() -> list:
-    """Return the current UI event log as a list of events.
+def get_ui_event_log() -> list[dict[str, Any]]:
+    """Return the logged events in chronological (insertion) order.
 
-    Reads the JSON array stored at UI_EVENT_LOG_PATH and returns it as Python
-    objects; if the file cannot be read or parsed, an empty list is returned.
-
-    Returns:
-        list: The list of logged UI events, or an empty list on error.
+    Returns an empty list if the log cannot be read or a row cannot be parsed.
     """
     try:
-        with _ui_event_log_lock, _ui_event_log_path.open(encoding="utf-8") as f:
-            return json.load(f)
-    except Exception:
+        with db.connection() as conn:
+            rows = conn.execute("SELECT data FROM events ORDER BY id").fetchall()
+        return [json.loads(row["data"]) for row in rows]
+    except (json.JSONDecodeError, sqlite3.Error):
         return []
 
 
 def clear_ui_event_log() -> bool:
     """Clear all events from the event log (all sessions)."""
     try:
-        _logger.info("[UIEventLog] Attempting to clear event log at: %s", _ui_event_log_path)
-        with _ui_event_log_lock, _ui_event_log_path.open("w", encoding="utf-8") as f:
-            json.dump([], f)
-        _logger.info("[UIEventLog] Successfully cleared event log at: %s", _ui_event_log_path)
-    except Exception as e:
-        _logger.error("[UIEventLog] Failed to clear event log at %s: %s", _ui_event_log_path, e)
+        with db.connection() as conn:
+            conn.execute("DELETE FROM events")
+            conn.commit()
+    except sqlite3.Error as e:
+        _logger.error("[UIEventLog] Failed to clear event log: %s", e)
         return False
     else:
         return True
@@ -91,13 +69,10 @@ def clear_ui_event_log() -> bool:
 def clear_ui_event_log_for_session(label: str) -> bool:
     """Remove all events for a specific session label from the event log."""
     try:
-        with _ui_event_log_lock:
-            with _ui_event_log_path.open(encoding="utf-8") as f:
-                log = json.load(f)
-            filtered_log = [event for event in log if event.get("label") != label]
-            with _ui_event_log_path.open("w", encoding="utf-8") as f:
-                json.dump(filtered_log, f, indent=2)
-    except Exception as e:
+        with db.connection() as conn:
+            conn.execute("DELETE FROM events WHERE label = ?", (label,))
+            conn.commit()
+    except sqlite3.Error as e:
         _logger.error("[UIEventLog] Failed to clear event log for session '%s': %s", label, e)
         return False
     else:

--- a/docs/architecture-and-rules.md
+++ b/docs/architecture-and-rules.md
@@ -152,7 +152,7 @@ MouseTrap supports notifications via Email (SMTP) and Webhook (including Discord
 ## File/Directory Structure (Key Parts)
 - `backend/`: FastAPI app, automation logic, event log, config/session management
 - `frontend/`: React app, UI components, event log panel, status card
-- `logs/ui_event_log.json`: Stores all UI-visible event log entries
+- `config/mousetrap.db`: SQLite database storing all UI-visible event log entries
 - `config/`: YAML config/session files
 
 ---

--- a/docs/features-guide.md
+++ b/docs/features-guide.md
@@ -442,7 +442,6 @@ services:
       - LOGLEVEL=INFO
     volumes:
       - ./config:/config
-      - ./logs:/app/logs
       - /var/run/docker.sock:/var/run/docker.sock:ro
     ports:
       - "127.0.0.1:39842:39842"  # Bind to localhost only

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -78,7 +78,6 @@ services:
       - DOCKER_HOST=tcp://docker-proxy:2375
     volumes:
       - ./config:/config
-      - ./logs:/app/logs
     networks:
       - mousetrap-network
     depends_on:
@@ -318,7 +317,6 @@ environment:
 
 **Key Log Locations:**
 - **Container logs**: `docker logs mousetrap`
-- **Persistent logs**: `./logs/` directory (if mounted)
 - **Event log**: Available in Web UI under Event Log button
 
 **Common Log Patterns:**
@@ -370,11 +368,11 @@ services:
 - **Increase check frequency**: Don't check more often than every 5-10 minutes
 - **Rate limiting awareness**: MaM rate limits API calls (once per hour)
 
-**Log File Growth:**
-```bash
-# Rotate/clear large log files:
-docker exec mousetrap rm -f /app/logs/*.log
-# Or configure log rotation in Docker:
+**Container Log Growth:**
+
+Logs go to the container's stdout; configure Docker's log rotation to cap their size:
+
+```yaml
 logging:
   driver: "json-file"
   options:
@@ -442,7 +440,7 @@ docker restart mousetrap
 rm config/proxies.yaml          # Reset proxy configs
 rm config/notify.yaml           # Reset notification configs
 rm config/session-*.yaml        # Reset all sessions
-rm logs/ui_event_log.json       # Clear event log
+rm config/mousetrap.db*         # Clear event log
 
 # Backup before changes
 cp -r config/ config-backup/
@@ -476,7 +474,6 @@ services:
       - DOCKER_GID=1000      # This one is fine as-is
     volumes:
       - ./config:/config
-      - ./logs:/app/logs
 ```
 
 **Alternative Solution:**

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -24,11 +24,6 @@ export default defineConfig(() => {
           target: backendUrl,
           changeOrigin: true,
         },
-        // Proxy logs (served by backend) so fetch('/logs/...') works in dev
-        '/logs': {
-          target: backendUrl,
-          changeOrigin: true,
-        },
       },
     },
     build: {

--- a/start.sh
+++ b/start.sh
@@ -105,8 +105,7 @@ FINAL_GID=$(id -g "$USERNAME" 2>/dev/null)
 FINAL_GROUPS=$(id -G "$USERNAME" 2>/dev/null)
 log_info "User '$USERNAME' successfully configured with PUID:$FINAL_UID PGID:$FINAL_GID Groups:$FINAL_GROUPS"
 
-# Ensure ownership of /app/logs and /config if they exist
-chown -R "$PUID":"$PGID" /app/logs 2>/dev/null || true
+# Ensure ownership of /config if it exists
 chown -R "$PUID":"$PGID" /config 2>/dev/null || true
 
 # Normalize LOGLEVEL to lowercase and map common values


### PR DESCRIPTION
**SQLite event log.** The UI event log rewrites its whole JSON array on every event (read, append, truncate to 1000, write back), which is O(n) per event under a held lock. This backs it with SQLite: appends are an `INSERT` plus a bounded `DELETE`, reads an indexed `SELECT`, per-session clears an indexed `DELETE`. A small `backend/db.py` owns the WAL-mode connection and schema behind a lock, with the event log as its first table. The database is at `<CONFIG_DIR>/mousetrap.db`, and `sqlite3` is stdlib, so no new dependency. The `/api/ui_event_log` contract, redaction, 1000-entry cap, and ordering are unchanged, so callers are untouched; the old `logs/ui_event_log.json` is not migrated, so the log starts empty.

  **Retiring `logs/`.** The event log was the only thing under `LOG_DIR`: app logging and uvicorn both write to stdout, and the frontend reads via `/api/ui_event_log`, not the `/logs` mount. With the log in the database, `logs/` is unused, so this also drops the dead plumbing: the `/logs` mount, `LOG_DIR` and its docs, the vite `/logs` proxy, the `/app/logs` chown, and the `./logs:/app/logs` compose volumes. Container logs remain on stdout.