### PR TITLE
chore(mypy): retire the test suite's type-checking exemption

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,25 +93,15 @@ warn_unused_configs = true
 warn_unused_ignores = true
 enable_error_code = ["deprecated", "ignore-without-code", "redundant-self", "truthy-iterable"]
 disable_error_code = ["annotation-unchecked"]
-extra_checks = false
+extra_checks = true
 check_untyped_defs = true
 disallow_incomplete_defs = true
-disallow_subclassing_any = false
+disallow_subclassing_any = true
 disallow_untyped_calls = true
-disallow_untyped_decorators = false
+disallow_untyped_decorators = true
 disallow_untyped_defs = true
 warn_return_any = false
 warn_unreachable = false
-
-[[tool.mypy.overrides]]
-module = "tests.backend.*"
-ignore_missing_imports = true
-disallow_untyped_defs = false
-disallow_untyped_calls = false
-disallow_incomplete_defs = false
-disable_error_code = ["import-untyped", "arg-type", "method-assign", "no-untyped-def", "no-untyped-call", "index", "union-attr", "operator"]
-check_untyped_defs = false
-warn_unused_ignores = false
 
 [tool.ruff]
 line-length = 100

--- a/tests/backend/integration/test_session_proxy_events.py
+++ b/tests/backend/integration/test_session_proxy_events.py
@@ -14,7 +14,8 @@ async def test_session_lifecycle_persists_events(
 ) -> None:
     """Create, read, update, and delete a session through HTTP."""
     monkeypatch.setattr(app, "register_session_job", lambda _label: None)
-    payload = {"label": "seedbox", "mam": {"mam_id": "cookie-one"}, "proxy": {}}
+    mam = {"mam_id": "cookie-one"}
+    payload: dict[str, object] = {"label": "seedbox", "mam": mam, "proxy": {}}
 
     created = await api_client.post("/api/session/save", json=payload)
     assert created.json() == {"success": True}
@@ -22,7 +23,7 @@ async def test_session_lifecycle_persists_events(
     assert (await api_client.get("/api/sessions")).json() == {"sessions": ["seedbox"]}
     assert (await api_client.get("/api/session/seedbox")).json()["mam"]["mam_id"] == "cookie-one"
 
-    payload["mam"]["mam_id"] = "cookie-two"
+    mam["mam_id"] = "cookie-two"
     payload["old_label"] = "seedbox"
     payload["label"] = "archive"
     assert (await api_client.post("/api/session/save", json=payload)).json() == {"success": True}

--- a/tests/backend/test_app_session_save.py
+++ b/tests/backend/test_app_session_save.py
@@ -1,24 +1,28 @@
 """Focused backend API session-persistence tests."""
 
 import asyncio
+import json
 from pathlib import Path
 from typing import Any
 
 import pytest
+from starlette.requests import Request
+from starlette.types import Message
 
 from backend import app, config
 
 
-class JsonRequest:
-    """Minimal request double."""
+def json_request(payload: dict[str, Any]) -> Request:
+    """Build a save-session request carrying the payload as its JSON body."""
 
-    def __init__(self, payload: dict[str, Any]) -> None:
-        """Store the request body."""
-        self.payload = payload
+    async def receive() -> Message:
+        """Deliver the whole encoded body as a single ASGI message."""
+        return {"type": "http.request", "body": json.dumps(payload).encode(), "more_body": False}
 
-    async def json(self) -> dict[str, Any]:
-        """Return the configured request body."""
-        return self.payload
+    return Request(
+        {"type": "http", "method": "POST", "path": "/api/session/save", "headers": []},
+        receive,
+    )
 
 
 def test_save_persists_once_before_side_effects(
@@ -40,7 +44,7 @@ def test_save_persists_once_before_side_effects(
 
     monkeypatch.setattr(app, "_sync_integrations_if_mam_id_changed", sync)
     result = asyncio.run(
-        app.api_save_session(JsonRequest({"label": "Example", "mam": {"mam_id": "id"}}))
+        app.api_save_session(json_request({"label": "Example", "mam": {"mam_id": "id"}}))
     )
     assert result == {"success": True}
     assert calls == ["save", "clear", "event", "job", "sync"]
@@ -64,7 +68,7 @@ def test_save_replaces_corrupt_existing_session(
     monkeypatch.setattr(app, "_sync_integrations_if_mam_id_changed", sync)
     result = asyncio.run(
         app.api_save_session(
-            JsonRequest(
+            json_request(
                 {
                     "label": "Existing",
                     "old_label": "Existing",
@@ -94,7 +98,7 @@ def test_post_save_side_effect_failure_returns_success(
 
     monkeypatch.setattr(app, "clear_ui_event_log_for_session", fail_clear)
     result = asyncio.run(
-        app.api_save_session(JsonRequest({"label": "Example", "mam": {"mam_id": "id"}}))
+        app.api_save_session(json_request({"label": "Example", "mam": {"mam_id": "id"}}))
     )
     assert result == {"success": True}
     assert calls == ["save", "clear"]

--- a/tests/backend/test_automation_shutdown.py
+++ b/tests/backend/test_automation_shutdown.py
@@ -1,7 +1,6 @@
 """Regression tests for cooperative automation shutdown."""
 
 import asyncio
-from copy import deepcopy
 from datetime import UTC, datetime, tzinfo
 import threading
 from typing import Self
@@ -16,16 +15,15 @@ def test_shutdown_finishes_current_purchase_and_skips_later_work(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Persist an accepted purchase before stopping later sessions and phases."""
+    first_upload_credit: dict[str, object] = {
+        "enabled": True,
+        "trigger_type": "points",
+        "trigger_point_threshold": 50_000,
+        "gb": 50,
+    }
     first_config = {
         "mam": {"mam_id": "first-id"},
-        "perk_automation": {
-            "upload_credit": {
-                "enabled": True,
-                "trigger_type": "points",
-                "trigger_point_threshold": 50_000,
-                "gb": 50,
-            }
-        },
+        "perk_automation": {"upload_credit": first_upload_credit},
     }
     second_config = {
         "mam": {"mam_id": "second-id"},
@@ -38,11 +36,13 @@ def test_shutdown_finishes_current_purchase_and_skips_later_work(
             }
         },
     }
-    expected_first_config = deepcopy(first_config)
-    fixed_now = datetime(2026, 8, 3, 12, 34, 56, tzinfo=UTC)
-    expected_first_config["perk_automation"]["upload_credit"]["last_upload_time"] = (
-        fixed_now.isoformat()
-    )
+    expected_upload_credit = first_upload_credit | {
+        "last_upload_time": "2026-08-03T12:34:56+00:00",
+    }
+    expected_first_config = {
+        "mam": {"mam_id": "first-id"},
+        "perk_automation": {"upload_credit": expected_upload_credit},
+    }
     purchase_started = threading.Event()
     release_purchase = threading.Event()
     saved_labels: list[str] = []
@@ -67,9 +67,6 @@ def test_shutdown_finishes_current_purchase_and_skips_later_work(
 
     def save(config: dict[str, object], *, old_label: str) -> None:
         assert config == expected_first_config
-        assert config["perk_automation"]["upload_credit"]["last_upload_time"] == (
-            "2026-08-03T12:34:56+00:00"
-        )
         saved_labels.append(old_label)
 
     monkeypatch.setattr(automation, "list_sessions", lambda: ["first", "second"])

--- a/tests/backend/test_port_monitor.py
+++ b/tests/backend/test_port_monitor.py
@@ -220,10 +220,12 @@ def test_shutdown_event_replacement_and_restart_registration_share_lock(
     monkeypatch.setattr(manager, "_run_monitor_loop", lambda: None)
 
     async def register_restart() -> None:
-        task = manager._register_restart_task()
-        assert task is asyncio.current_task()
+        running_task = asyncio.current_task()
+        if running_task is None:
+            raise RuntimeError("Restart registration must run inside an asyncio task")
+        assert manager._register_restart_task() is running_task
         registered.set()
-        manager._unregister_restart_task(task)
+        manager._unregister_restart_task(running_task)
 
     registration_thread = threading.Thread(target=lambda: asyncio.run(register_restart()))
     start_thread = threading.Thread(target=manager.start)


### PR DESCRIPTION
`pyproject.toml` carries a `[[tool.mypy.overrides]]` block that exempts `tests.backend.*` from type checking: eight relaxations plus an eight-code `disable_error_code` list. The test suite does not need it.

Deleting the block surfaces seven errors, all in test code, and each is a genuine typing gap rather than a false positive:

- `tests/backend/test_app_session_save.py` passed a local `JsonRequest` double into `app.api_save_session`, whose parameter is annotated `Request`. The helper now builds a real `starlette.requests.Request` from an ASGI scope and a `receive` callable, so the tests exercise the actual body-read path instead of a stand-in that only implements `json()`.
- `tests/backend/test_port_monitor.py` fed the result of `_register_restart_task()` straight into `_unregister_restart_task()`. `_register_restart_task()` returns `None` when the shutdown event is already set, and that branch was unhandled. The test now asserts registration returned the running task, which is the claim it was making implicitly.
- `tests/backend/test_automation_shutdown.py` and `tests/backend/integration/test_session_proxy_events.py` indexed into nested dict literals whose inferred value type is `object`. Each mutated leaf now has its own name, so nothing indexes through the joined type. No `Any` was introduced.

The same commit sets `extra_checks`, `disallow_subclassing_any` and `disallow_untyped_decorators` to `true`. Each was explicitly `false`, which is also mypy's default, so the lines documented a weakening without buying anything; enabling all three costs zero errors.

No runtime behaviour changes, no new `# type: ignore`, and no suppression added anywhere. Verified locally: `mypy backend tests` reports no issues across 45 source files, `./scripts/lint.sh` is green including the pinned `mirrors-mypy` hook, and `./scripts/test.sh` is green on backend pytest (74 passed) and the Playwright e2e suite.
