### PR TITLE
fix(ip_lookup): release the response on the error path

### DIFF
--- a/backend/ip_lookup.py
+++ b/backend/ip_lookup.py
@@ -164,125 +164,128 @@ async def get_ipinfo_with_fallback(
             try:
                 # Choose proxy per-request. If multiple proxy schemes are available
                 # we already selected a proxy_url above.
-                resp = await session.get(
+                # The context manager releases the response on every exit path,
+                # including an exception raised while normalizing the payload.
+                async with session.get(
                     url, headers=request_headers, proxy=proxy_url, proxy_auth=proxy_auth
-                )
-                if resp.status != 200:
-                    _logger.warning(
-                        "%s lookup failed for IP %s: HTTP %s",
-                        provider,
-                        ip or "self",
-                        resp.status,
-                    )
-                    await resp.release()
-                    continue
-
-                try:
-                    if provider == "httpbin_hardcoded":
-                        # httpbin returns plain text, not JSON
-                        text = await resp.text()
-                        data = {"ip": text.strip()}
-                    else:
-                        data = await resp.json()
-                except Exception as json_e:
-                    _logger.warning(
-                        "%s lookup failed for IP %s: Invalid JSON response - %s",
-                        provider,
-                        ip or "self",
-                        json_e,
-                    )
-                    await resp.release()
-                    continue
-
-                _logger.debug("%s raw response for IP %s: %s", provider, ip or "self", data)
-                _logger.debug("%s lookup successful for IP %s", provider, ip or "self")
-
-                # Normalize output for ipinfo_lite and ipinfo_standard
-                result = None
-                if provider in ("ipinfo_lite", "ipinfo_standard"):
-                    # ipinfo_lite: ip, asn, as_name, as_domain, country_code, country, continent_code, continent
-                    # ipinfo_standard: ip, org, etc.
-                    if provider == "ipinfo_lite":
-                        asn_num = data.get("asn")
-                        as_name = data.get("as_name", "")
-                        # Combine ASN number with name for consistency with other providers
-                        # Check if asn_num already has "AS" prefix to avoid duplication
-                        asn_prefix = asn_num if str(asn_num).startswith("AS") else f"AS{asn_num}"
-                        asn_val = (
-                            f"{asn_prefix} {as_name}".strip()
-                            if asn_num and as_name
-                            else (asn_num or as_name or "")
+                ) as resp:
+                    if resp.status != 200:
+                        _logger.warning(
+                            "%s lookup failed for IP %s: HTTP %s",
+                            provider,
+                            ip or "self",
+                            resp.status,
                         )
-                        org_val = as_name
-                    else:
+                        continue
+
+                    try:
+                        if provider == "httpbin_hardcoded":
+                            # httpbin returns plain text, not JSON
+                            text = await resp.text()
+                            data = {"ip": text.strip()}
+                        else:
+                            data = await resp.json()
+                    except Exception as json_e:
+                        _logger.warning(
+                            "%s lookup failed for IP %s: Invalid JSON response - %s",
+                            provider,
+                            ip or "self",
+                            json_e,
+                        )
+                        continue
+
+                    _logger.debug("%s raw response for IP %s: %s", provider, ip or "self", data)
+                    _logger.debug("%s lookup successful for IP %s", provider, ip or "self")
+
+                    # Normalize output for ipinfo_lite and ipinfo_standard
+                    result = None
+                    if provider in ("ipinfo_lite", "ipinfo_standard"):
+                        # ipinfo_lite: ip, asn, as_name, as_domain, country_code, country, continent_code, continent
+                        # ipinfo_standard: ip, org, etc.
+                        if provider == "ipinfo_lite":
+                            asn_num = data.get("asn")
+                            as_name = data.get("as_name", "")
+                            # Combine ASN number with name for consistency with other providers
+                            # Check if asn_num already has "AS" prefix to avoid duplication
+                            asn_prefix = (
+                                asn_num if str(asn_num).startswith("AS") else f"AS{asn_num}"
+                            )
+                            asn_val = (
+                                f"{asn_prefix} {as_name}".strip()
+                                if asn_num and as_name
+                                else (asn_num or as_name or "")
+                            )
+                            org_val = as_name
+                        else:
+                            asn_val = str(data.get("org", ""))
+                            org_val = data.get("org", "")
+                        result = {
+                            "ip": data.get("ip"),
+                            "asn": asn_val,
+                            "org": org_val,
+                            "timezone": data.get(
+                                "timezone", None
+                            ),  # Not present in lite, but included for compatibility
+                        }
+                    elif provider == "ipify":
+                        # ipify only returns IP, no ASN data - return None for ASN to indicate unavailable
+                        result = {
+                            "ip": data.get("ip"),
+                            "asn": None,  # Use None instead of "Unknown ASN" to indicate unavailable data
+                            "org": "",
+                            "timezone": None,
+                        }
+                    elif provider == "ipinfo_hardcoded":
+                        # ipinfo.io via hardcoded IP (same format as ipinfo_standard)
                         asn_val = str(data.get("org", ""))
                         org_val = data.get("org", "")
-                    result = {
-                        "ip": data.get("ip"),
-                        "asn": asn_val,
-                        "org": org_val,
-                        "timezone": data.get(
-                            "timezone", None
-                        ),  # Not present in lite, but included for compatibility
-                    }
-                elif provider == "ipify":
-                    # ipify only returns IP, no ASN data - return None for ASN to indicate unavailable
-                    result = {
-                        "ip": data.get("ip"),
-                        "asn": None,  # Use None instead of "Unknown ASN" to indicate unavailable data
-                        "org": "",
-                        "timezone": None,
-                    }
-                elif provider == "ipinfo_hardcoded":
-                    # ipinfo.io via hardcoded IP (same format as ipinfo_standard)
-                    asn_val = str(data.get("org", ""))
-                    org_val = data.get("org", "")
-                    result = {
-                        "ip": data.get("ip"),
-                        "asn": asn_val,
-                        "org": org_val,
-                        "timezone": data.get("timezone", None),
-                    }
-                elif provider == "httpbin_hardcoded":
-                    # httpbin.org/ip returns just the IP as plain text, handled above
-                    result = {"ip": data.get("ip"), "asn": None, "org": "", "timezone": None}
-                elif provider == "ipapi":
-                    # ipapi returns "as" field which may already contain "AS" prefix
-                    asn_val = str(data.get("as", ""))
-                    result = {
-                        "ip": data.get("query"),
-                        "asn": asn_val,
-                        "org": data.get("org", ""),
-                        "timezone": data.get("timezone", None),
-                    }
-                elif provider == "ipdata":
-                    asn: dict[str, Any] | str | None = data.get("asn", {})
-                    if isinstance(asn, dict):
-                        asn_num = asn.get("asn", "")
-                        asn_name = asn.get("name", "")
-                        # Check if asn_num already has "AS" prefix to avoid duplication
-                        asn_prefix = asn_num if str(asn_num).startswith("AS") else f"AS{asn_num}"
-                        asn_str = (
-                            f"{asn_prefix} {asn_name}".strip()
-                            if asn_num and asn_name
-                            else (asn_num or asn_name or "")
-                        )
-                        org_name = asn_name
-                    else:
-                        asn_str = str(asn) if asn else ""
-                        org_name = ""
-                    result = {
-                        "ip": data.get("ip"),
-                        "asn": asn_str,
-                        "org": org_name,
-                        "timezone": data.get("time_zone", None),
-                    }
+                        result = {
+                            "ip": data.get("ip"),
+                            "asn": asn_val,
+                            "org": org_val,
+                            "timezone": data.get("timezone", None),
+                        }
+                    elif provider == "httpbin_hardcoded":
+                        # httpbin.org/ip returns just the IP as plain text, handled above
+                        result = {"ip": data.get("ip"), "asn": None, "org": "", "timezone": None}
+                    elif provider == "ipapi":
+                        # ipapi returns "as" field which may already contain "AS" prefix
+                        asn_val = str(data.get("as", ""))
+                        result = {
+                            "ip": data.get("query"),
+                            "asn": asn_val,
+                            "org": data.get("org", ""),
+                            "timezone": data.get("timezone", None),
+                        }
+                    elif provider == "ipdata":
+                        asn: dict[str, Any] | str | None = data.get("asn", {})
+                        if isinstance(asn, dict):
+                            asn_num = asn.get("asn", "")
+                            asn_name = asn.get("name", "")
+                            # Check if asn_num already has "AS" prefix to avoid duplication
+                            asn_prefix = (
+                                asn_num if str(asn_num).startswith("AS") else f"AS{asn_num}"
+                            )
+                            asn_str = (
+                                f"{asn_prefix} {asn_name}".strip()
+                                if asn_num and asn_name
+                                else (asn_num or asn_name or "")
+                            )
+                            org_name = asn_name
+                        else:
+                            asn_str = str(asn) if asn else ""
+                            org_name = ""
+                        result = {
+                            "ip": data.get("ip"),
+                            "asn": asn_str,
+                            "org": org_name,
+                            "timezone": data.get("time_zone", None),
+                        }
 
-                # Cache the successful result
-                if result:
-                    _ip_cache[cache_key] = (result, current_time)
-                    await resp.release()
-                    return result
+                    # Cache the successful result
+                    if result:
+                        _ip_cache[cache_key] = (result, current_time)
+                        return result
 
             except Exception as e:
                 _logger.warning("%s lookup failed for IP %s: %s", provider, ip or "self", e)

--- a/tests/backend/test_ip_lookup.py
+++ b/tests/backend/test_ip_lookup.py
@@ -1,0 +1,217 @@
+"""Backend IP lookup tests for provider-chain response handling."""
+
+from collections.abc import Generator
+from types import TracebackType
+from typing import Any, Self
+
+import pytest
+
+from backend import ip_lookup
+
+# ip-api.com, ipinfo.io standard, and ipdata.co: the providers offered for a
+# specific IP once the two token-gated entries are removed from the chain.
+PROVIDERS_FOR_A_SPECIFIC_IP = 3
+
+
+class _Noop:
+    """Awaitable no-op mirroring the return value of ``aiohttp`` ``release()``."""
+
+    def __await__(self) -> Generator[None]:
+        """Yield once so the value is awaitable but harmless when discarded."""
+        yield
+
+
+class _StubResponse:
+    """Stub ``aiohttp`` response that counts how often it is released."""
+
+    def __init__(self, payload: Any, status: int = 200) -> None:
+        """Record the payload and status this stub replays to the caller.
+
+        Args:
+            payload: Value returned by ``json()``, or rendered by ``text()``.
+            status: HTTP status the stub reports.
+
+        """
+        self.status = status
+        self.releases = 0
+        self._payload = payload
+
+    async def json(self) -> Any:
+        """Return the configured payload."""
+        return self._payload
+
+    async def text(self) -> str:
+        """Return the configured payload rendered as text."""
+        return str(self._payload)
+
+    def release(self) -> _Noop:
+        """Count the release and return an awaitable, as ``aiohttp`` does."""
+        self.releases += 1
+        return _Noop()
+
+    async def __aenter__(self) -> Self:
+        """Enter the response context."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Release the response on every exit path, as ``aiohttp`` does."""
+        self.release()
+
+
+class _StubRequest:
+    """Stub request handle that is both awaitable and an async context manager."""
+
+    def __init__(self, response: _StubResponse) -> None:
+        """Bind the response this handle resolves to.
+
+        Args:
+            response: Response returned by both the await and the context entry.
+
+        """
+        self._response = response
+
+    def __await__(self) -> Generator[Any, None, _StubResponse]:
+        """Resolve to the response, matching an un-managed ``session.get()``."""
+        return self._resolve().__await__()
+
+    async def _resolve(self) -> _StubResponse:
+        """Return the bound response."""
+        return self._response
+
+    async def __aenter__(self) -> _StubResponse:
+        """Enter the underlying response context."""
+        return await self._response.__aenter__()
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Exit the underlying response context."""
+        await self._response.__aexit__(exc_type, exc, tb)
+
+
+class _StubSession:
+    """Stub ``aiohttp`` session handing out one prepared response per request."""
+
+    def __init__(self, response_factory: Any) -> None:
+        """Bind the factory that builds a response per request.
+
+        Args:
+            response_factory: Zero-argument callable returning a stub response.
+
+        """
+        self.responses: list[_StubResponse] = []
+        self._response_factory = response_factory
+
+    def get(self, _url: str, **_kwargs: Any) -> _StubRequest:
+        """Return a request handle for a freshly built response."""
+        response = self._response_factory()
+        self.responses.append(response)
+        return _StubRequest(response)
+
+    async def __aenter__(self) -> Self:
+        """Enter the session context."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Exit the session context."""
+
+
+@pytest.fixture
+def stub_lookup_chain(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Replace the provider chain's session and cache with test-local doubles."""
+    monkeypatch.delenv("IPINFO_TOKEN", raising=False)
+    monkeypatch.delenv("IPDATA_API_KEY", raising=False)
+    monkeypatch.setattr(ip_lookup, "_ip_cache", {})
+    monkeypatch.setattr(ip_lookup, "_last_cache_log_time", {})
+
+    def install(response_factory: Any) -> _StubSession:
+        """Install a stub session built from the supplied response factory.
+
+        Args:
+            response_factory: Zero-argument callable returning a stub response.
+
+        Returns:
+            The stub session the lookup will use, for post-run assertions.
+
+        """
+        session = _StubSession(response_factory)
+        monkeypatch.setattr(
+            ip_lookup.aiohttp, "ClientSession", lambda **_kwargs: session, raising=True
+        )
+        return session
+
+    return install
+
+
+async def test_response_is_released_when_normalization_raises(stub_lookup_chain: Any) -> None:
+    """Release the response even when parsing the decoded payload raises."""
+    # A JSON list decodes cleanly and then fails the provider normalizers, which
+    # all call `data.get(...)`, so the failure lands on the outer error path.
+    session = stub_lookup_chain(lambda: _StubResponse([]))
+
+    result = await ip_lookup.get_ipinfo_with_fallback("203.0.113.7")
+
+    assert result == {"ip": None, "asn": None, "org": "", "timezone": None}
+    assert len(session.responses) == PROVIDERS_FOR_A_SPECIFIC_IP
+    assert [response.releases for response in session.responses] == [
+        1
+    ] * PROVIDERS_FOR_A_SPECIFIC_IP
+
+
+async def test_response_is_released_on_a_non_200_status(stub_lookup_chain: Any) -> None:
+    """Release the response when a provider answers with a non-200 status."""
+    session = stub_lookup_chain(lambda: _StubResponse({}, status=503))
+
+    result = await ip_lookup.get_ipinfo_with_fallback("203.0.113.7")
+
+    assert result == {"ip": None, "asn": None, "org": "", "timezone": None}
+    assert [response.releases for response in session.responses] == [
+        1
+    ] * PROVIDERS_FOR_A_SPECIFIC_IP
+
+
+async def test_response_is_released_on_invalid_json(
+    monkeypatch: pytest.MonkeyPatch, stub_lookup_chain: Any
+) -> None:
+    """Release the response when a provider body fails to decode as JSON."""
+
+    async def raise_decode_error(_self: _StubResponse) -> Any:
+        """Fail as an undecodable body would."""
+        raise ValueError("not json")
+
+    monkeypatch.setattr(_StubResponse, "json", raise_decode_error)
+    session = stub_lookup_chain(lambda: _StubResponse(None))
+
+    result = await ip_lookup.get_ipinfo_with_fallback("203.0.113.7")
+
+    assert result == {"ip": None, "asn": None, "org": "", "timezone": None}
+    assert [response.releases for response in session.responses] == [
+        1
+    ] * PROVIDERS_FOR_A_SPECIFIC_IP
+
+
+async def test_response_is_released_on_the_success_path(stub_lookup_chain: Any) -> None:
+    """Release the response once a provider returns a usable payload."""
+    session = stub_lookup_chain(
+        lambda: _StubResponse({"ip": "203.0.113.7", "asn": {"asn": "64500", "name": "TEST-NET"}})
+    )
+
+    result = await ip_lookup.get_ipinfo_with_fallback("203.0.113.7")
+
+    assert result["ip"] == "203.0.113.7"
+    assert result["asn"] == "AS64500 TEST-NET"
+    assert len(session.responses) == 1
+    assert session.responses[0].releases == 1


### PR DESCRIPTION
**Response leak on the error path.** `get_ipinfo_with_fallback` binds `resp = await session.get(...)` without a context manager and calls `await resp.release()` on the two `continue` paths and on the success path, but not on the surrounding `except`. Every provider normalizer reads the decoded body with `data.get(...)`, so a payload that decodes cleanly but is not a mapping (a bare JSON list, for example) raises inside the `try` and leaves the connection held until garbage collection. Each provider in the fallback chain that hits it leaks another one.

This binds the request with `async with` instead, so release is unconditional and the three explicit `release()` calls go away rather than a fourth being added. That is also the shape every other `aiohttp` call site in `backend/` already uses. Behaviour is otherwise unchanged: the same statuses are logged, the same providers are tried in the same order, and the same normalized dict is returned.

Adds `tests/backend/test_ip_lookup.py`, covering release on all four exit paths: the normalization failure above, a non-200 status, an undecodable body, and the success path. The normalization test fails on the pre-fix code with `assert [0, 0, 0] == [1, 1, 1]`.

Validation: `./scripts/lint.sh` and `./scripts/test.sh` both clean. No user-visible behaviour changes, so no `README.md`, `docs/`, or `AGENTS.md` updates apply.
