### PR TITLE
fix(jackett): stop requiring admin_password

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2394,10 +2394,10 @@ async def api_jackett_update(request: Request) -> dict[str, Any]:
         api_key = jackett_cfg.get("api_key", "").strip()
         admin_password = jackett_cfg.get("admin_password", "").strip()
 
-        if not all([host, port, api_key, admin_password]):
+        if not all([host, port, api_key]):
             return {
                 "success": False,
-                "message": "Jackett configuration incomplete (host, port, api_key, admin_password required)",
+                "message": "Jackett configuration incomplete (host, port, api_key required)",
             }
 
         result = await sync_mam_id_to_jackett(host, port, api_key, admin_password, mam_id)
@@ -2680,7 +2680,7 @@ async def api_indexer_update(request: Request) -> dict[str, Any]:
                 api_key = jackett_cfg.get("api_key", "").strip()
                 admin_password = jackett_cfg.get("admin_password", "").strip()
 
-                if not all([host, port, api_key, admin_password]):
+                if not all([host, port, api_key]):
                     failed_services.append("Jackett (incomplete configuration)")
                 else:
                     result = await sync_mam_id_to_jackett(

--- a/frontend/src/components/IndexerIntegrations.jsx
+++ b/frontend/src/components/IndexerIntegrations.jsx
@@ -606,7 +606,6 @@ export default function IndexerIntegrations({
                     label="Admin Password (Optional)"
                     onChange={(e) => handleJackettChange('admin_password', e.target.value)}
                     placeholder="Leave empty if Jackett auth is disabled"
-                    required
                     size="small"
                     sx={{ maxWidth: 350 }}
                     type="password"

--- a/tests/backend/integration/test_notifications_indexer.py
+++ b/tests/backend/integration/test_notifications_indexer.py
@@ -98,3 +98,68 @@ async def test_unified_indexer_update_reports_partial_success(
     events = (await api_client.get("/api/ui_event_log")).json()
     assert events[-1]["event"] == "indexer_partial_update"
     assert events[-1]["event_type"] == "indexer_update"
+
+
+AUTH_DISABLED_JACKETT_SESSION = {
+    "label": "seedbox",
+    "mam": {"mam_id": "new-cookie"},
+    "proxy": {},
+    "jackett": {
+        "enabled": True,
+        "host": "jackett.local",
+        "port": 9117,
+        "api_key": "secret",
+        "admin_password": "",
+    },
+}
+
+
+@pytest.mark.integration
+async def test_jackett_update_accepts_an_auth_disabled_instance(
+    api_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sync a Jackett instance that has authentication disabled, so no admin password."""
+    monkeypatch.setattr(app, "register_session_job", lambda _label: None)
+    assert (
+        await api_client.post("/api/session/save", json=AUTH_DISABLED_JACKETT_SESSION)
+    ).is_success
+    synced: list[tuple[str, int, str, str, str]] = []
+
+    async def jackett_success(
+        host: str, port: int, api_key: str, admin_password: str, mam_id: str
+    ) -> dict:
+        synced.append((host, port, api_key, admin_password, mam_id))
+        return {"success": True, "message": "updated"}
+
+    monkeypatch.setattr(app, "sync_mam_id_to_jackett", jackett_success)
+    response = await api_client.post("/api/jackett/update", json={"label": "seedbox"})
+
+    assert response.json() == {"success": True, "message": "updated"}
+    assert synced == [("jackett.local", 9117, "secret", "", "new-cookie")]
+
+
+@pytest.mark.integration
+async def test_unified_indexer_update_accepts_an_auth_disabled_jackett(
+    api_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reach the same auth-disabled Jackett through the unified indexer endpoint."""
+    monkeypatch.setattr(app, "register_session_job", lambda _label: None)
+    assert (
+        await api_client.post("/api/session/save", json=AUTH_DISABLED_JACKETT_SESSION)
+    ).is_success
+    synced: list[tuple[str, int, str, str, str]] = []
+
+    async def jackett_success(
+        host: str, port: int, api_key: str, admin_password: str, mam_id: str
+    ) -> dict:
+        synced.append((host, port, api_key, admin_password, mam_id))
+        return {"success": True, "message": "updated"}
+
+    monkeypatch.setattr(app, "sync_mam_id_to_jackett", jackett_success)
+    response = await api_client.post("/api/indexer/update", json={"label": "seedbox"})
+
+    assert response.json() == {
+        "success": True,
+        "message": "Successfully updated MAM ID in Jackett",
+    }
+    assert synced == [("jackett.local", 9117, "secret", "", "new-cookie")]


### PR DESCRIPTION
Jackett's admin password is optional — it is only set if authentication is enabled in Jackett — but two of the three code paths that sync a MAM ID to Jackett refuse to run without one.

`api_jackett_update` (`app.py:2397`) and `api_indexer_update` (`app.py:2683`) both put `admin_password` inside `all([...])` and report "configuration incomplete". The auto-update-on-save path (`app.py:1548-1549`) does not — it syncs with no completeness check at all. So the same Jackett instance with authentication disabled updates fine when a session is saved, and is rejected as incomplete from the manual and unified update buttons.

The rest of the code already treats the empty password as valid:

- `jackett_integration.py` is written for it throughout — `jackett_login` documents `admin_password` as "empty string if auth disabled" (`:37`), and branches on it at `:64`, `:70`, `:132`, `:174`.
- `api_jackett_test` (`app.py:2351`) gates on `host`, `port`, `api_key` only and passes `admin_password or ""` through.
- The frontend sends `payload.admin_password = config.admin_password || ''` (`IndexerIntegrations.jsx:163-165`).
- `docs/jackett-integration.md` already tells users the field is optional and to "leave Admin Password blank" if Jackett authentication is disabled, and `docs/indexer-integrations.md` says the same.

What changed:

- Dropped `admin_password` from both completeness gates. It is still read and still passed to `sync_mam_id_to_jackett`; only the gate stops requiring it.
- Updated the message at `app.py:2400` to match, which also brings it in line with the AudioBookRequest and Autobrr messages in the same function (`(host, port, api_key required)`).
- Removed the stray `required` prop on the field labelled "Admin Password (Optional)" (`IndexerIntegrations.jsx:609`), which rendered a required asterisk on an optional field. It was the only `required` in that file not on a Host, Port, or API Key.
- Added two integration tests covering an auth-disabled Jackett through `/api/jackett/update` and `/api/indexer/update`. There was no Jackett coverage before. Both were confirmed failing against the old gates before the fix.

No documentation changes: the docs already describe the intended behaviour, and this makes the code match them. No configuration or data-format change — a session with a populated `admin_password` behaves exactly as before.

Validation, both clean: `./scripts/lint.sh` (16/16 hooks, plus frontend audit and the Vite production build) and `./scripts/test.sh` (backend pytest PASS, development Playwright E2E 5 passed).
