### PR TITLE
chore(ruff): retire eight settings that restate ruff's defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,19 +105,14 @@ warn_unreachable = false
 
 [tool.ruff]
 line-length = 100
-indent-width = 4
 fix = true
 force-exclude = true
 target-version = "py313"
 required-version = ">=0.15.0"
 
 [tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
-skip-magic-trailing-comma = false
 line-ending = "lf"
 docstring-code-format = true
-docstring-code-line-length = "dynamic"
 
 [tool.ruff.lint]
 select = [
@@ -234,17 +229,12 @@ ignore = [
     "PLW0602", # Unused global
     "TRY002", # Create your own exception class
 ]
-fixable = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/backend/**/*.py" = [
     "S101", # Use of assert detected
     "SLF001", # Private member accessed
 ]
-
-[tool.ruff.lint.flake8-pytest-style]
-fixture-parentheses = false
-mark-parentheses = false
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "async_timeout".msg = "use asyncio.timeout instead"


### PR DESCRIPTION
Follow-on to #81, same shape: a measurement, therefore a deletion. #81 removed the parts of the inherited `[tool.ruff]` config that suppressed nothing. This removes the parts that *decide* nothing — eight options explicitly set to the value Ruff already uses by default. They read as deliberate choices and are not; deleting them leaves the config stating only what the project actually chose.

| Setting | Set to | Ruff's default |
|---|---|---|
| `indent-width` | `4` | `4` |
| `format.quote-style` | `"double"` | `"double"` |
| `format.indent-style` | `"space"` | `"space"` |
| `format.skip-magic-trailing-comma` | `false` | `false` |
| `format.docstring-code-line-length` | `"dynamic"` | `"dynamic"` |
| `lint.fixable` | `["ALL"]` | `["ALL"]` |
| `lint.flake8-pytest-style.fixture-parentheses` | `false` | `false` |
| `lint.flake8-pytest-style.mark-parentheses` | `false` | `false` |

The last two are the whole content of `[tool.ruff.lint.flake8-pytest-style]`, so the now-empty table header goes with them. `"PT"` stays in `select` and the flake8-pytest-style rules are unaffected — only the two lines restating their own defaults are removed.

**Evidence.** `ruff config <key>` prints the default for each key. All eight print the value the file sets, at three versions: **0.15.0**, which is this repo's declared floor (`required-version = ">=0.15.0"`); **0.16.1**, the rev `prek.toml:95` pins for CI; and **0.16.2**. Because the oldest Ruff the config permits already defaults to all eight, `required-version` needs no bump and is not touched.

**Verification.** Not inferred from the defaults — measured on the tree. Before and after the deletion, `ruff check --show-settings` produces a **byte-identical** resolved configuration (52,479 bytes both sides, empty diff), and `ruff check`, `ruff format --check` and `ruff format --diff` are byte-identical too. `ruff check` reports `All checks passed!` at both revisions.

**Not touched.** `line-length = 100`, `fix`, `force-exclude`, `target-version`, `required-version`, `format.line-ending`, `format.docstring-code-format`, `[tool.ruff.lint.isort]` and `[tool.ruff.lint.pydocstyle]` all differ from Ruff's defaults and are load-bearing. The `ignore` list and `per-file-ignores` are suppressions, a separate question from default-restatement, and are left exactly as #81 left them.

**Behaviour**: none. **Files**: `pyproject.toml`, deletions only.

**Validation**: `./scripts/lint.sh` (16/16 hooks, `npm audit` clean, `vite build` clean) and `./scripts/test.sh` (backend pytest PASS, Playwright E2E 5 passed) both pass. No documentation mentions any of the eight — `AGENTS.md:32`'s "pytest, coverage, mypy, and Ruff configuration" stays true — and no test asserts on configuration content, so nothing else needed updating.
