### PR TITLE
refactor(jackett): drop the unread response binding

### DIFF
--- a/backend/jackett_integration.py
+++ b/backend/jackett_integration.py
@@ -48,7 +48,7 @@ async def jackett_login(host: str, port: int, admin_password: str) -> str | None
 
         async with aiohttp.ClientSession(cookie_jar=jar) as session:
             # Step 1: GET /UI/Login to receive TestCookie and Jackett session cookie
-            async with session.get(login_url, allow_redirects=True, timeout=_TIMEOUT) as response:
+            async with session.get(login_url, allow_redirects=True, timeout=_TIMEOUT):
                 # Get all cookies after visiting login page
                 cookies = session.cookie_jar.filter_cookies(URL(build_service_url(host, port)))
 


### PR DESCRIPTION
## Summary

`backend/jackett_integration.py:51` bound a response object that the block never reads:

```python
async with session.get(login_url, allow_redirects=True, timeout=_TIMEOUT) as response:
```

Every line inside that block goes through `session.cookie_jar` instead: the `filter_cookies(...)` call, the two `any(...)` cookie scans, and both returns. The name `response` is never read there. Dropping the `as response` keeps the context manager (so the response is still released) and removes the misleading binding.

The second `async with ... as response` in the same function is genuinely read (`await response.text()` and `str(response.url)`), and is untouched. That second binding is almost certainly why the first was written this way.

## Why the linter does not catch this

`F841` is enabled here (`"F"` is in `select`, and neither `ignore` nor `per-file-ignores` excludes it), and the rule's domain does cover `async with` bindings. A probe over stdin with a single unread `async with ... as response:` reports:

```text
F841 Local variable `response` is assigned to but never used
```

But `ruff check backend/jackett_integration.py` is clean on this file. The reason is shadowing: with two `async with ... as response` bindings in one function, the first unread and the second read, ruff resolves the name as used in the enclosing function scope and reports nothing. Removing the second binding from the probe makes `F841` fire on the first. That is exactly this file's shape, so the defect is invisible to the gate.

Measured with ruff 0.16.2; `prek.toml` pins `ruff-pre-commit` at `v0.16.1`.

## Behaviour

None. Deleting an unread binding changes nothing observable.

## Tests

No test changes. Nothing in `tests/` imports `jackett_integration`, and because the change is unobservable there is no assertion that could distinguish before from after. Stating this explicitly rather than leaving it silent.

## Docs

None go stale. `docs/jackett-integration.md:13` documents this request as "**GET `/UI/Login`** — retrieves the required `TestCookie` and `Jackett` session cookie", which is what the block does through `session.cookie_jar`, and stays correct verbatim. `README.md` and `AGENTS.md` do not name the module.

## Validation

- `./scripts/lint.sh` — all 16 hooks pass, frontend audit and production build clean.
- `./scripts/test.sh` — backend pytest PASS, frontend Playwright E2E PASS.
