### PR TITLE
fix(biome): resync the pinned hook rev so CI enforces the doctype it flags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">

--- a/prek.toml
+++ b/prek.toml
@@ -115,7 +115,7 @@ pass_filenames = false
 
 [[repos]]
 repo = "https://github.com/biomejs/pre-commit"
-rev = "v2.5.6"
+rev = "v2.5.7"
 
 [[repos.hooks]]
 id = "biome-check"


### PR DESCRIPTION
## Summary

The Biome prek hook is pinned one release behind the repo's own Biome package, and that gap is exactly why `frontend/index.html` fails a local `biome check` while CI reports the "Run Linters" job green.

`prek.toml` pins `biomejs/pre-commit` at `v2.5.6`, which resolves `"@biomejs/biome": "2.5.6"`. `frontend/package.json` pins `"@biomejs/biome": "2.5.7"`. The lowercase-HTML5-doctype formatter change shipped in 2.5.7 (biomejs/biome#11106); 2.5.6's complementary entry, biomejs/biome#11071, only taught the parser to *accept* mixed-case doctypes. So the version the repo declares flags `<!DOCTYPE html>` and the version CI runs does not.

Nothing excludes the file from the hook. prek selects it (`matched=true filenames=43`, and the dry-run list contains `frontend/index.html` verbatim) and Biome checks it (`Checked 1 file`, exit 0). The only difference is the binary version.

## Changes

- `prek.toml`: `rev = "v2.5.6"` to `rev = "v2.5.7"`. Produced by `node scripts/sync-biome-prek-hook.mjs "$(node -p "require('./frontend/package.json').devDependencies['@biomejs/biome']")" prek.toml`, not hand-edited. The script prints `Updated Biome prek hook to v2.5.7 for Biome 2.5.7.`
- `frontend/index.html`: `<!DOCTYPE html>` to `<!doctype html>`. Written by the hook itself at the new rev, not typed.

## This changes what CI enforces, and that is the point

Moving the hook from 2.5.6 to 2.5.7 makes every diagnostic added in 2.5.7 a CI failure from the merge onward. At this commit that set is exactly one finding, the `index.html` doctype, measured head-to-head over the identical 43-file list prek passes. This is a behaviour change to the lint gate, not routine maintenance.

## Why one commit and not two

Neither half is shippable alone:

- The `<!doctype>` correction alone is **unverifiable by CI**, because the 2.5.6 the hook runs does not flag it and never will.
- The rev bump alone turns **CI red**, because 2.5.7 flags a file the tree still carries in the old form. Verified directly: with the rev bumped and `index.html` untouched, `prek run biome-check --all-files` fails with `Checked 39 files in 299ms. Fixed 1 file.`

They are the same defect from two ends: the hook configuration claims to enforce a formatter version the repo has already adopted, and does not.

## How the drift was created

`scripts/sync-biome-prek-hook.mjs:46` filters candidate tags to those no newer than the npm pin. When a Biome bump lands before the `biomejs/pre-commit` mirror tags that release, the hook pins one release behind and stays there until `update-dependencies.sh` runs again *and* the npm pin moves again. `2ac89f209` did exactly that:

```
$ git show 2ac89f209 -- frontend/package.json | grep biome
-    "@biomejs/biome": "2.5.5",
+    "@biomejs/biome": "2.5.7",
$ git show 2ac89f209 -- prek.toml | grep '^[+-]rev'
-rev = "v2.5.5"
+rev = "v2.5.6"
```

`v2.5.7` now exists upstream, so the drift is stale rather than structural. `README.md:553` documents the helper as selecting "the newest published stable Biome prek tag in the same major version that is no newer than the npm package"; resyncing to `v2.5.7` against a `2.5.7` pin is exactly that behaviour, so no documentation changes.

## Validation

All run in a local environment reproducing the repo's toolchain.

```
$ prek run biome-check --all-files            # before the doctype fix, after the rev bump
biome check..............................................................Failed
  Checked 39 files in 299ms. Fixed 1 file.

$ prek run biome-check --all-files            # after
biome check..............................................................Passed

$ prek run biome-check --all-files --dry-run -v
  `biome-check` would be run on 43 files:
  - frontend/index.html

$ node ~/.cache/prek/hooks/node-<id>/bin/biome --version
Version: 2.5.7
```

- `./scripts/lint.sh` — clean, 16/16 hooks pass, frontend audit clean, production build succeeds.
- `./scripts/test.sh` — clean. Backend pytest PASS, Frontend Playwright E2E PASS (5 passed).

## Tests and docs

No test asserts the doctype either way (`grep -rni doctype tests/ frontend/e2e/ scripts/` returns nothing) and none should: the assertion belongs to the formatter, and the hook running at 2.5.7 *is* the regression test. `frontend/index.html` is the Vite entry template, so the Playwright E2E run exercises the served page and confirms the lowercased doctype changes nothing at runtime. The production bundle's `build/index.html` carries it through unchanged. No backend code is touched, so no pytest coverage applies.

`README.md:553` was checked and is not made stale. `AGENTS.md:34` ("repository hook configuration") and `AGENTS.md:76` (Biome checks for frontend changes) both remain accurate.

## Deployment and data compatibility

None. The doctype is case-insensitive per the HTML standard, so the served page is byte-different and semantically identical.

## Scope

Deliberately narrow. Not touched here, each worth its own change: the `files = "^frontend/"` scope on the Biome hook, which replaces rather than intersects the upstream extension filter and leaves `biome.json`, the root `package.json` and both `scripts/*.mjs` checked by nothing; `biome.json`'s `$schema` URL; the `a11y` rule group; and bumping `@biomejs/biome` itself past 2.5.7.

One ordering note if a Biome bump is in flight: bumping the package to 2.5.8 first would take the hook to `v2.5.8` and turn CI red on `frontend/index.html` unless that change also carried the doctype correction. Landing this first removes that trap.
