### PR TITLE
refactor(ip_lookup): drop the unreachable provider-header fallback

### DIFF
--- a/backend/ip_lookup.py
+++ b/backend/ip_lookup.py
@@ -158,8 +158,7 @@ async def get_ipinfo_with_fallback(
 
     async with aiohttp.ClientSession(timeout=timeout) as session:
         for provider_data in providers:
-            url, provider = provider_data[0], provider_data[1]
-            request_headers = provider_data[2] if len(provider_data) > 2 else headers
+            url, provider, request_headers = provider_data
 
             try:
                 # Choose proxy per-request. If multiple proxy schemes are available


### PR DESCRIPTION
## Summary

`get_ipinfo_with_fallback` unpacks each provider entry by index and hedges on its length:

```python
url, provider = provider_data[0], provider_data[1]
request_headers = provider_data[2] if len(provider_data) > 2 else headers
```

The `else headers` arm cannot be reached. Every `providers.append(...)` in the function pushes a three-tuple, so `len(provider_data) > 2` is unconditionally true. `grep -n "providers.append" backend/ip_lookup.py` returns exactly seven lines (`:79`, `:100`, `:107`, `:115`, `:120`, `:126`, `:130`), every one a three-tuple, and `providers` is a local that is never passed in, returned, or mutated elsewhere, so those seven are the whole population.

Replacing both lines with a tuple unpack also makes the shape assumption enforced rather than assumed: `mypy` infers `providers` as `list[tuple[str, str, dict[str, str]]]`, so a future two-tuple `append` is a type error, and at runtime the unpack raises instead of silently substituting a `headers` value the author never chose.

## Behavior changes

None. The deleted branch was unreachable.

## Files touched

- `backend/ip_lookup.py` — two lines become one.

No documentation changes: the provider tuple is a local variable inside one function with no user-visible or API surface. `README.md:145-148` and `docs/ip-lookup-optimization.md` enumerate the fallback chain by provider name, which this does not touch.

No test changes: `tests/backend/test_ip_lookup.py` substitutes `aiohttp.ClientSession` and the module cache with test-local doubles and never constructs a provider tuple, so nothing pins the indexed form. Since the removed arm was unreachable, there is no old behavior to pin and no new behavior to cover.

## Validation

- `./scripts/lint.sh` — clean, all 16 hooks pass (mypy, ruff check, ruff format, tsc, biome included).
- `./scripts/test.sh` — backend pytest PASS, frontend Playwright E2E PASS. `tests/backend/test_ip_lookup.py` is 4 passed, unchanged.

## Deployment / data-compatibility notes

None.
