### PR TITLE
chore(frontend): declare the react type dependencies tsc relies on

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,8 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.7",
         "@playwright/test": "^1.62.1",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.7",
         "@vitejs/plugin-react": "^5.2.0",
         "concurrently": "^9.2.4",
         "istanbul-lib-coverage": "^3.2.2",
@@ -2230,9 +2232,18 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-transition-group": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,8 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.7",
     "@playwright/test": "^1.62.1",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.7",
     "@vitejs/plugin-react": "^5.2.0",
     "concurrently": "^9.2.4",
     "istanbul-lib-coverage": "^3.2.2",


### PR DESCRIPTION
## Summary

`frontend/package.json` declares no `@types/*` entry of any kind, yet the project type-checks React. `@types/react` is in the lockfile at 19.2.18 marked `"peer": true` and is nobody's direct dependency: it reaches the tree because `@mui/material` depends on `@types/react-transition-group`, which peer-depends on `@types/react: "*"` **non-optionally**. (The `@mui/*` packages' own `@types/react` peer is optional and would not pull it in.) `@types/react-dom` is not in the lockfile at all, so `import ReactDOM from 'react-dom/client'` in `src/index.jsx` has no declarations behind it.

This declares both at the majors matching `react` / `react-dom`, and regenerates the lockfile. Two lines plus the lockfile; no source changes.

## Why it matters

A dependency that arrives as a peer of a transitive dependency disappears when the intermediate restructures its own `dependencies`, and that restructure is a change to MUI's internals, not to any version constraint declared here. There is no semver signal: `@mui/material` can drop `@types/react-transition-group` in a minor release and this project's React type coverage vanishes with nothing failing, because `checkJs` under `strict: false` infers `any` for an untyped import rather than erroring.

The `react-dom` half is not hypothetical, it is already unchecked. Measured on `main` before this change:

```
$ npx tsc --noEmit --noImplicitAny 2>&1 | grep index.jsx
src/index.jsx(2,22): error TS7016: Could not find a declaration file for module 'react-dom/client'.
  '.../node_modules/react-dom/client.js' implicitly has an 'any' type.
```

That is invisible under the current `tsconfig.json` because `strict: false` leaves `noImplicitAny` off. A negative control shows what the missing declarations cost. Editing `src/index.jsx` to `ReactDOM.createRoot(42)` type-checks **clean** on `main`; with `@types/react-dom` declared, the same edit reports:

```
src/index.jsx(7,34): error TS2345: Argument of type 'number' is not assignable to parameter of type 'Container'.
```

So the whole `react-dom/client` surface is currently unchecked, and this change turns the check on.

## What changes

`frontend/package.json` gains `"@types/react": "^19.2.18"` and `"@types/react-dom": "^19.2.7"` in `devDependencies`. In `frontend/package-lock.json`, `node_modules/@types/react` loses its `"peer": true` marker and a `node_modules/@types/react-dom` entry appears. Neither package carries an install script, so `allowScripts` is untouched and `npm ci --strict-allow-scripts` stays clean.

`npm --prefix frontend run tsc` still reports **0 errors**. The program grows from 812 to 814 files (`@types/react-dom/index.d.ts` and `client.d.ts`), and the count under `--noImplicitAny` drops 217 to 216, which is the `TS7016` above being retired.

No documentation change: `README.md`, `docs/` and `AGENTS.md` never enumerate frontend dependencies. No test change: this touches no backend code, and the type checker is the assertion.

## Validation

```
./scripts/lint.sh              # 16/16 hooks pass, frontend build clean
./scripts/test.sh              # backend pytest PASS, frontend Playwright E2E PASS
npm --prefix frontend run tsc  # 0 errors
npm ci --prefix frontend --strict-allow-scripts   # clean, 222 packages
```

No deployment or data-compatibility notes; the production image is unaffected beyond two extra dev packages in the discarded frontend build stage.
