### PR TITLE
refactor(port_monitor): retire twelve unreachable getattr defaults

### DIFF
--- a/backend/api_port_monitor.py
+++ b/backend/api_port_monitor.py
@@ -174,12 +174,12 @@ def list_stacks() -> list[PortMonitorStackModel]:
             primary_container=s.primary_container,
             primary_port=s.primary_port,
             secondary_containers=s.secondary_containers,
-            interval=getattr(s, "interval", 60),
+            interval=s.interval,
             status=s.status,
             last_checked=s.last_checked,
             last_result=s.last_result,
-            public_ip=getattr(s, "public_ip", None),
-            public_ip_detected=getattr(s, "public_ip_detected", None),
+            public_ip=s.public_ip,
+            public_ip_detected=s.public_ip_detected,
         )
         for s in port_monitor_manager.list_stacks()
     ]

--- a/backend/port_monitor.py
+++ b/backend/port_monitor.py
@@ -179,9 +179,9 @@ class PortMonitorStackManager:
                     "primary_container": s.primary_container,
                     "primary_port": s.primary_port,
                     "secondary_containers": s.secondary_containers,
-                    "interval": getattr(s, "interval", 60),
-                    "public_ip": getattr(s, "public_ip", None),
-                    "public_ip_detected": getattr(s, "public_ip_detected", None),
+                    "interval": s.interval,
+                    "public_ip": s.public_ip,
+                    "public_ip_detected": s.public_ip_detected,
                 }
                 for s in self.stacks
             ],
@@ -253,7 +253,7 @@ class PortMonitorStackManager:
         stack = next((s for s in self.stacks if s.primary_container == container_name), None)
         ip = None
         public_ip_detected = False
-        if stack and getattr(stack, "public_ip", None):
+        if stack and stack.public_ip:
             ip = stack.public_ip
             _logger.info(
                 "[PortMonitorStack] Using manual public_ip override for %s: %s",
@@ -631,11 +631,11 @@ class PortMonitorStackManager:
             now = time.time()
             for stack in self.stacks:
                 # Only check if enough time has passed since last check
-                interval_min = getattr(stack, "interval", 60)  # interval in minutes
+                interval_min = stack.interval  # interval in minutes
                 interval_sec = interval_min * 60
                 if not stack.last_checked or (now - stack.last_checked) >= interval_sec:
                     # Manual IP failure tracking logic
-                    manual_ip = getattr(stack, "public_ip", None)
+                    manual_ip = stack.public_ip
                     result = self.check_port(stack.primary_container, stack.primary_port)
                     if not self.running:
                         return
@@ -668,7 +668,7 @@ class PortMonitorStackManager:
                                 "primary_container": stack.primary_container,
                                 "primary_port": stack.primary_port,
                                 "result": result,
-                                "interval": getattr(stack, "interval", 60),
+                                "interval": stack.interval,
                                 "secondaries": stack.secondary_containers,
                             },
                             "level": "primary" if result else "warning",
@@ -676,9 +676,7 @@ class PortMonitorStackManager:
                     )
                     if manual_ip:
                         if not result:
-                            stack.consecutive_manual_ip_failures = (
-                                getattr(stack, "consecutive_manual_ip_failures", 0) + 1
-                            )
+                            stack.consecutive_manual_ip_failures += 1
                             if stack.consecutive_manual_ip_failures >= 3:
                                 stack.manual_ip_paused = True
                                 append_ui_event_log(
@@ -709,7 +707,7 @@ class PortMonitorStackManager:
                             stack.consecutive_manual_ip_failures = 0
                             stack.manual_ip_paused = False
                     if not result:
-                        if getattr(stack, "manual_ip_paused", False):
+                        if stack.manual_ip_paused:
                             continue  # Don't restart if paused
                         await safe_notify_event(
                             event_type="port_monitor_failure",

--- a/tests/backend/test_port_monitor.py
+++ b/tests/backend/test_port_monitor.py
@@ -18,6 +18,24 @@ def _raise_yaml_store_error(*_args: object, **_kwargs: object) -> None:
     raise YamlStoreError
 
 
+def test_stack_defines_every_attribute_from_four_arguments() -> None:
+    """A minimally-constructed stack still carries all twelve attributes."""
+    stack = port_monitor.PortMonitorStack("x", "container", 80, [])
+
+    assert stack.name == "x"
+    assert stack.primary_container == "container"
+    assert stack.primary_port == 80
+    assert stack.secondary_containers == []
+    assert stack.interval == 60
+    assert stack.status == "Unknown"
+    assert stack.last_checked == 0.0
+    assert stack.last_result is False
+    assert stack.public_ip is None
+    assert stack.public_ip_detected is None
+    assert stack.consecutive_manual_ip_failures == 0
+    assert stack.manual_ip_paused is False
+
+
 def test_constructor_does_not_load(monkeypatch: pytest.MonkeyPatch) -> None:
     """Construction has no configuration I/O side effect."""
     monkeypatch.setattr(


### PR DESCRIPTION
`PortMonitorStack.__init__` (`backend/port_monitor.py:47-79`) assigns all twelve of its attributes unconditionally on every instance. So every `getattr(stack, "<name>", <default>)` in the port-monitor code is an attribute read wearing a hedge that cannot fire. This replaces all twelve with the plain attribute read.

## The twelve sites

Nine in `backend/port_monitor.py`:

| Line | Expression |
|---|---|
| `:182` | `getattr(s, "interval", 60)` |
| `:183` | `getattr(s, "public_ip", None)` |
| `:184` | `getattr(s, "public_ip_detected", None)` |
| `:256` | `getattr(stack, "public_ip", None)` |
| `:634` | `getattr(stack, "interval", 60)` |
| `:638` | `getattr(stack, "public_ip", None)` |
| `:671` | `getattr(stack, "interval", 60)` |
| `:680` | `getattr(stack, "consecutive_manual_ip_failures", 0)` |
| `:712` | `getattr(stack, "manual_ip_paused", False)` |

Three in `backend/api_port_monitor.py`, in `list_stacks`' response construction:

| Line | Expression |
|---|---|
| `:177` | `interval=getattr(s, "interval", 60)` |
| `:181` | `public_ip=getattr(s, "public_ip", None)` |
| `:182` | `public_ip_detected=getattr(s, "public_ip_detected", None)` |

`grep -n 'getattr(' backend/port_monitor.py backend/api_port_monitor.py` returns exactly those twelve before the change and nothing after. Neither file contains any other `getattr` call.

## Why the defaults cannot be reached

`__init__` at `:68-79` is twelve unconditional assignment statements with no branch among them: `name`, `primary_container`, `primary_port`, `secondary_containers`, `interval`, `status`, `last_checked`, `last_result`, `public_ip`, `public_ip_detected`, `consecutive_manual_ip_failures`, `manual_ip_paused`. Nothing anywhere can remove one:

- `rg -n '__slots__|__getattr__|^\s*del ' backend/` returns two hits, both dictionary-key deletions (`app.py:203`, `api_proxy.py:77`) and neither on a stack. There is no `__slots__` and no `__getattr__` in the backend.
- `rg -n 'setattr\(' backend/` returns exactly one site, the rollback loop at `api_port_monitor.py:105`, which restores five keys that are all `__init__` fields. `setattr` can add an attribute, never remove one.
- `self.stacks` is only ever populated by `PortMonitorStack(...)` at `port_monitor.py:150` and `:542`, and `list_stacks` is declared `-> list[PortMonitorStack]` at `:597`, which is what the three `api_port_monitor.py` sites iterate.

## Why one PR across two files

The claim is a single property of `PortMonitorStack`, and the proof is the paragraph above. Split in two, the second PR would either restate it or ask you to take it on faith. The `api_port_monitor.py` half also cannot be argued without the first file: `list_stacks()` returns the object defined there, so a PR editing only the router still has to reach across the import to justify itself. The whole change is twelve one-line edits and no behaviour.

The three router sites additionally erase declared types: `getattr` returns `Any`, and those three feed a Pydantic constructor whose fields are `int`, `str | None` and `bool | None` (`api_port_monitor.py:141`, `:145`, `:148`). Their neighbours at `:173-180` are already read directly, so the file is internally inconsistent about it today.

If you would rather have them separate, the seam is by file: drop the three `api_port_monitor.py` edits and the remaining nine stand alone unchanged.

## No behaviour change, including on disk

Three of the nine (`:182-184`) sit inside `save_stacks`, which writes the user's `port_monitoring_stacks.yaml`. That is the one place a silently-wrong default would cost something real, so it is worth stating explicitly: the keys written are the same seven in the same order, sourced from attributes that are always present, so the on-disk shape is byte-for-byte what it was.

The one site that is not a bare read is `:680`, where `stack.consecutive_manual_ip_failures = getattr(...) + 1` becomes `stack.consecutive_manual_ip_failures += 1`. The literal `x = x + 1` form is 104 characters at that indent and would trip `E501` against `line-length = 100`.

## Scope

Deliberately not included: `PortMonitorStack` is **not** converted to a dataclass and no `to_config_dict` is added. That is a different change with a different argument, and it carries a subtlety this title would not prepare a reviewer for: `eq=False` would be load-bearing rather than stylistic, because `port_monitor.py:554` is `self.stacks.remove(stack)` inside `add_stack`'s `YamlStoreError` rollback, and `list.remove` tests `==` before identity. A plain `@dataclass` would change which element is removed when two stacks share field values, and `tests/backend/test_port_monitor.py:575` is where that would surface. Worth doing separately; not here.

## Tests

The existing suite passes unmodified, which is the assertion that no behaviour changed: 80 passed before, 81 after.

The one net-new test is what this change makes both possible and necessary. `test_stack_defines_every_attribute_from_four_arguments` constructs a stack with the minimum four positional arguments and asserts all twelve attributes are present with their documented defaults. Before this PR that fact was load-bearing and untested; after it the code depends on it directly rather than hedging against it.

Verified the test is not a no-op by deleting `self.manual_ip_paused = False` from `__init__`: the new test fails with `AttributeError: 'PortMonitorStack' object has no attribute 'manual_ip_paused'`, and three pre-existing monitor-loop tests fail at the changed `port_monitor.py:709` alongside it. Assignment restored.

## Docs

None apply, checked rather than assumed. The three places that name `port_monitoring_stacks.yaml` (`README.md:160`, `README.md:333`, `docs/features-guide.md:361`) stay correct because the on-disk shape is unchanged, and none of them enumerates the keys. No signature or return type moves, so no docstring changes.

`./scripts/lint.sh` (16/16 hooks) and `./scripts/test.sh` (backend pytest + Playwright e2e) both clean.
