### PR TITLE
refactor(app): stop re-widening the MAM classification to str

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -60,6 +60,7 @@ from backend.ip_lookup import get_asn_and_timezone_from_ip, get_ipinfo_with_fall
 from backend.jackett_integration import sync_mam_id_to_jackett, test_jackett_connection
 from backend.last_session_api import router as last_session_router, write_last_session
 from backend.mam_api import (
+    MamResponseClass,
     classify_mam_response,
     get_mam_seen_ip_info,
     get_proxied_public_ip,
@@ -416,7 +417,7 @@ def api_automation_guardrails() -> dict[str, Any]:
 async def apply_mam_validity_classification(
     cfg: dict[str, Any],
     label: str,
-    classification: str,
+    classification: MamResponseClass,
     now: datetime,
     detail: str = "",
 ) -> None:


### PR DESCRIPTION
`classify_mam_response()` returns `MamResponseClass`, the `Literal["ok", "invalid_cookie", "other_error"]` alias declared alongside it in `backend/mam_api.py`. `apply_mam_validity_classification()` then declares its `classification` parameter as `str` and discards that type at the call boundary, so nothing checks that a caller passes a value the function actually branches on.

This annotates the parameter `MamResponseClass` and imports the alias from `backend.mam_api`, which `backend/app.py` already imports `classify_mam_response` from. Two lines, no runtime change.

All four call sites already pass a valid value: `app.py:527` and `app.py:843` forward a `classify_mam_response()` return, and `app.py:750` and `app.py:785` pass the literal `"ok"`. Nothing needed fixing to make the narrower type fit.

The annotation is load-bearing rather than decorative. Changing one `"ok"` call site to `"okay"` produces, with the change:

```text
backend/app.py:750: error: Argument 3 to "apply_mam_validity_classification" has incompatible type "Literal['okay']"; expected "Literal['ok', 'invalid_cookie', 'other_error']"  [arg-type]
```

and, with the parameter back at `str`, mypy reports `Success: no issues found in 27 source files` on the same broken call. A typo in any of the three classification strings is currently silent: the function's `if`/`elif` chain would simply take neither branch and leave the cookie-validity bookkeeping untouched.

**No tests added.** This is a type annotation with no runtime effect, and there is no new behaviour to cover, so please do not look for tests that should not exist. The existing suite is unchanged and passing.

**No docs updated.** `docs/prowlarr-integration.md` and `docs/CHANGELOG.md` reference `classify_mam_response()` by name in flow descriptions, and neither they nor `README.md` or `AGENTS.md` document `apply_mam_validity_classification()`'s signature, so nothing is made stale. Checked rather than assumed.

## Validation

- `./scripts/lint.sh` — clean, all 16 hooks pass (mypy, ruff check, ruff format, tsc, biome included).
- `./scripts/test.sh` — clean, backend pytest and frontend Playwright E2E both PASS.
- `mypy backend/ tests/` — `Success: no issues found in 46 source files`.
