### PR TITLE
refactor(app): remove three no-op runtime introspection guards

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -596,7 +596,7 @@ async def auto_update_seedbox_if_needed(
             # Continue with normal processing without ASN change detection
         else:
             norm_last = extract_asn_number(last_seedbox_asn) if last_seedbox_asn else None
-            norm_check = extract_asn_number(asn_to_check) if "asn_to_check" in locals() else None
+            norm_check = extract_asn_number(asn_to_check)
             # Always store the normalized ASN number if available
             if norm_check is not None:
                 cfg["last_seedbox_asn"] = norm_check
@@ -1160,7 +1160,7 @@ async def api_status(label: str = Query(None), force: int = Query(0)) -> dict[st
             save_session(cfg, old_label=label)
             _logger.info("[SessionCheck] mam_id cookie auto-refreshed for session '%s'", label)
             await _sync_integrations_if_mam_id_changed(cfg, label, mam_id, _prev_mam_id)
-        if "proxy_error" not in mam_status and "proxy_error" in locals() and proxy_error:
+        if "proxy_error" not in mam_status and proxy_error:
             mam_status["proxy_error"] = proxy_error
         mam_status["configured_ip"] = ip_to_use
         mam_status["configured_asn"] = asn

--- a/backend/app.py
+++ b/backend/app.py
@@ -11,7 +11,6 @@ import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
-import inspect
 import logging
 import os
 from pathlib import Path
@@ -2867,12 +2866,6 @@ async def session_check_job(label: str) -> None:
     """
     try:
         trigger_source = "scheduled"
-
-        frame = inspect.currentframe()
-        if frame is not None:
-            args, _, _, values = inspect.getargvalues(frame)
-            if "trigger_source" in values:
-                trigger_source = values["trigger_source"]
         _logger.info("[SessionCheck] label=%s source=%s", label, trigger_source)
         cfg = load_session(label)
         mam_id = cfg.get("mam", {}).get("mam_id", "")


### PR DESCRIPTION
Three places in `backend/app.py` use runtime introspection to test for a fact the code already knows statically. In every case the test cannot fail, so the guarded branch is either a self-assignment or an unconditional one.

**1. The `inspect`-based `trigger_source` lookup in `session_check_job` (`app.py:2869-2876`).** Dead twice over, and either proof alone is sufficient:

- No caller can reach it. `session_check_job(label)` takes one parameter, so no caller can pass a `trigger_source` for the lookup to find.
- The guard cannot be false. `inspect.getargvalues(frame)[3]` is `frame.f_locals`, which already contains the name bound on the line above, so `"trigger_source" in values` is unconditionally true and the block re-assigns `"scheduled"` to itself.

Confirmed by running the block in isolation on the project's Python 3.13: `args == ['label']`, `values` contains `trigger_source`, and its value is `"scheduled"`. The log line it feeds still prints `source=scheduled`, exactly as `docs/ip-lookup-optimization.md:152` documents.

This also retires the unused `args` binding the block left behind and `import inspect` at `app.py:14`, whose only consumer it was.

**2. `"asn_to_check" in locals()` in `auto_update_seedbox_if_needed` (`app.py:600`).** `asn_to_check` is bound unconditionally at `:585`, and the line sits inside the `else` of `if asn_to_check is None or asn_to_check == "Unknown ASN"`, which cannot be reached unless the name is bound. So the conditional expression's `else None` arm is unreachable and `norm_check` is always `extract_asn_number(asn_to_check)`. Its type is unchanged: `extract_asn_number` returns `str | None` either way.

**3. `"proxy_error" in locals()` in `api_status` (`app.py:1164`).** `proxy_error = None` is assigned at function-body top level at `:989`, 175 lines earlier. The only earlier exit is the unconfigured-session `return`, so any flow that reaches `:1164` has passed the assignment. The remaining `and proxy_error` truthiness test is what the condition was always actually doing.

Five edits in one file, grouped as those three arguments, split into two commits so each is independently revertible: the `inspect` block together with the `args` binding and the import it was the only consumer of, then the two `locals()` conditions, which are one argument in two places.

No behaviour change, so no new tests: each deletion is proven above to leave the same value in the same variable. No documentation changes either, since nothing here is user-visible and the one doc that shows the affected log line (`docs/ip-lookup-optimization.md`) already prints the value this code produces before and after.

Validation, both clean: `./scripts/lint.sh` (16/16 hooks, plus frontend audit and the Vite production build) and `./scripts/test.sh` (backend pytest 80 passed, development Playwright E2E 5 passed).
