### PR TITLE
chore(biome): retire six settings and one exclusion that restate defaults

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,24 +8,19 @@
   "files": {
     "ignoreUnknown": true,
     "maxSize": 4194304,
-    "includes": ["**", "!**/build", "!**/public", "!**/node_modules"]
+    "includes": ["**", "!**/build", "!**/public"]
   },
   "formatter": {
-    "enabled": true,
     "indentStyle": "space",
-    "indentWidth": 2,
-    "lineEnding": "lf",
     "lineWidth": 100
   },
   "linter": {
-    "enabled": true,
     "rules": {
       "preset": "recommended",
       "correctness": {
         "noUnusedVariables": {
           "level": "error",
-          "fix": "safe",
-          "options": {}
+          "fix": "safe"
         }
       }
     },
@@ -36,8 +31,7 @@
   },
   "javascript": {
     "formatter": {
-      "quoteStyle": "single",
-      "trailingCommas": "all"
+      "quoteStyle": "single"
     }
   },
   "html": {


### PR DESCRIPTION
## Summary

`biome.json` sets six options to the value Biome already uses when they are absent, and excludes one path Biome already excludes by construction. None of them changes a single diagnostic or a single formatted byte. This deletes all seven. No source changes, no `$schema` change, no lockfile change.

| Line | Setting | Set to | Biome default |
|---|---|---|---|
| `:14` | `formatter.enabled` | `true` | `true` |
| `:16` | `formatter.indentWidth` | `2` | `2` |
| `:17` | `formatter.lineEnding` | `"lf"` | `lf` |
| `:21` | `linter.enabled` | `true` | `true` |
| `:28` | `linter.rules.correctness.noUnusedVariables.options` | `{}` | sets nothing |
| `:40` | `javascript.formatter.trailingCommas` | `"all"` | `all` |
| `:11` | the `"!**/node_modules"` entry of `files.includes` | excluded | excluded by construction |

## Why it matters

A setting that restates its tool's default states nothing while looking deliberate. It reads as a decision the project made, so the next person changing formatting has to work out which of these lines are load-bearing and which are noise before touching any of them. `indentStyle: "space"`, `lineWidth: 100`, `quoteStyle: "single"`, `files.maxSize`, `html.formatter.enabled` and `noUnusedVariables`'s `level`/`fix` all genuinely override a Biome default and are kept. After this change every remaining key in `biome.json` is one of those.

## Evidence

Each default was measured against the project's own pinned Biome, not read from the docs. The frontend exact-pins `@biomejs/biome` at **2.5.7** (`frontend/package.json:43`, resolved identically in `frontend/package-lock.json`), and the `biomejs/pre-commit` hook is pinned at **v2.5.6** (`prek.toml:118`), so every probe below was run twice, once per binary, with identical results.

`formatter.enabled` and `linter.enabled`, with no configuration file present at all:

```
$ printf 'const   x = {a:1,   b:2}\nconsole.log(x)\n' > misformatted.js
$ biome check misformatted.js
misformatted.js format ...
  × Formatter would have printed the following content:
Found 1 error.

$ echo '{"formatter":{"enabled":false}}' > biome.json   # negative control
$ biome check misformatted.js
Checked 1 file in 2ms. No fixes applied.
```

The same shape for the linter: with no config, `noDoubleEquals` and `noUnusedVariables` both fire; with `linter.enabled: false` the run reports `Checked 0 files`.

`indentWidth`, `lineEnding` and `trailingCommas`, holding `indentStyle: "space"` fixed so the tab default does not confound the reading:

```
$ echo '{"formatter":{"indentStyle":"space"}}' > biome.json
$ biome format --write sample.js le.js
```

produces two-space indentation, a trailing comma on the last object member, and LF endings from a CRLF input. Negative controls at `indentWidth: 8`, `trailingCommas: "none"` and `lineEnding: "crlf"` each change the output, so the probe is not a no-op.

`noUnusedVariables.options: {}` sets nothing: the shipped `configuration_schema.json` gives `NoUnusedVariablesOptions` exactly two properties, `ignore` and `ignoreRestSiblings`, both nullable with `additionalProperties: false`. A differential over a file exercising rest-sibling destructuring and a plain unused binding reports the same two diagnostics with and without the empty object.

`node_modules`, with no configuration file present:

```
$ biome check frontend/node_modules/react/index.js
... internalError/fs
  × The file .../node_modules/react/index.js does not exist in the workspace.
```

The same file copied outside `node_modules` reports `noRedundantUseStrict` plus a format diagnostic, so the exclusion is Biome's and not the file's.

## Validation

Before and after, in a devShell pinned to the repo's own toolchain:

```
npm --prefix frontend run lint          # byte-identical output
biome check .                           # byte-identical output, 43 files
prek run biome-check --all-files        # Passed, both revisions
biome format --write frontend/src       # no fixes applied
./scripts/lint.sh                       # 16/16 hooks pass, frontend build clean
./scripts/test.sh                       # backend pytest PASS, Playwright E2E PASS
```

`npm --prefix frontend run lint` reports the same single pre-existing `frontend/index.html` format diagnostic before and after, and `biome check .` the same three, so nothing in this change moves the needle in either direction. A stronger check than the already-formatted tree: `frontend/src` was copied twice, de-indented and converted to CRLF in both copies, then formatted once under the old configuration and once under the new. The two results are byte-identical across all 28 files, with 25 files rewritten in each run.

`scripts/update-dependencies.sh:113` runs `biome migrate --write --config-path biome.json`; against the new file it reports `no migration needed` and rewrites nothing, so routine dependency maintenance will not reintroduce the deleted keys.

## Documentation and tests

No documentation change. `README.md`, `docs/` and `AGENTS.md` never name any of the deleted settings; `AGENTS.md:13` and `:76` mention Biome only as the frontend formatter and linter, and `README.md:553` describes `update-dependencies.sh` keeping the Biome package pin and configuration schema aligned. All three stay true, in particular because `$schema` is untouched at `2.5.7`.

No test change. Nothing under `tests/` or `frontend/e2e/` reads `biome.json`; its only tracked consumers are `frontend/package.json:21-22`'s `lint` scripts and `scripts/update-dependencies.sh:113`. `scripts/sync-biome-prek-hook.mjs` reads `prek.toml`, not this file. No backend behaviour changes, so no pytest coverage is implicated.

No deployment or data-compatibility notes; `biome.json` is listed in `.dockerignore` and never reaches the image.
