### PR TITLE
refactor(mam_api): remove the unreachable outer exception handler

### DIFF
--- a/backend/mam_api.py
+++ b/backend/mam_api.py
@@ -40,24 +40,17 @@ async def get_proxied_public_ip(proxy_cfg: dict) -> str | None:
     proxies = build_proxy_dict(proxy_cfg)
     if not proxies:
         return None
+    proxy_url = proxies.get("https") or proxies.get("http") if isinstance(proxies, dict) else None
     try:
-        proxy_url = (
-            proxies.get("https") or proxies.get("http") if isinstance(proxies, dict) else None
-        )
-        try:
-            timeout = aiohttp.ClientTimeout(total=10)
-            async with (
-                aiohttp.ClientSession(timeout=timeout) as session,
-                session.get("https://api.ipify.org", timeout=timeout, proxy=proxy_url) as resp,
-            ):
-                text = await resp.text()
-                if resp.status == 200:
-                    return text.strip()
-        except Exception as e:
-            _logger.warning("[get_proxied_public_ip] Failed: %s", e)
-            return None
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with (
+            aiohttp.ClientSession(timeout=timeout) as session,
+            session.get("https://api.ipify.org", timeout=timeout, proxy=proxy_url) as resp,
+        ):
+            text = await resp.text()
+            if resp.status == 200:
+                return text.strip()
     except Exception as e:
-        # Defensive: preserve original behavior on unexpected errors
         _logger.warning("[get_proxied_public_ip] Failed: %s", e)
         return None
     return None

--- a/tests/backend/test_mam_api.py
+++ b/tests/backend/test_mam_api.py
@@ -1,0 +1,147 @@
+"""Backend MAM API tests for the proxied public IP lookup."""
+
+import logging
+from types import TracebackType
+from typing import Any, Self
+
+import aiohttp
+import pytest
+
+from backend import mam_api
+
+# `build_proxy_dict` renders host and port into the URL the lookup must proxy through.
+PROXY_CFG = {"host": "proxy.invalid", "port": 8080}
+PROXY_URL = "http://proxy.invalid:8080"
+IPIFY_URL = "https://api.ipify.org"
+
+
+class _StubResponse:
+    """Stub ``aiohttp`` response replaying a fixed status and body."""
+
+    def __init__(self, body: str, status: int) -> None:
+        """Record the status and body this stub replays to the caller.
+
+        Args:
+            body: Text returned by ``text()``.
+            status: HTTP status the stub reports.
+
+        """
+        self.status = status
+        self._body = body
+
+    async def text(self) -> str:
+        """Return the configured body."""
+        return self._body
+
+    async def __aenter__(self) -> Self:
+        """Enter the response context."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Exit the response context."""
+
+
+class _StubSession:
+    """Stub ``aiohttp`` session recording each request and replaying one outcome."""
+
+    def __init__(self, outcome: _StubResponse | Exception) -> None:
+        """Bind the outcome every request replays.
+
+        Args:
+            outcome: Response to hand back, or exception to raise from ``get()``.
+
+        """
+        self.requests: list[tuple[str, str | None]] = []
+        self._outcome = outcome
+
+    def get(self, url: str, *, proxy: str | None = None, **_kwargs: Any) -> _StubResponse:
+        """Record the requested URL and proxy, then replay the configured outcome."""
+        self.requests.append((url, proxy))
+        if isinstance(self._outcome, Exception):
+            raise self._outcome
+        return self._outcome
+
+    async def __aenter__(self) -> Self:
+        """Enter the session context."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Exit the session context."""
+
+
+@pytest.fixture
+def stub_session(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Replace the lookup's ``aiohttp`` session with a test-local double."""
+
+    def install(outcome: _StubResponse | Exception) -> _StubSession:
+        """Install a stub session replaying the supplied outcome.
+
+        Args:
+            outcome: Response to hand back, or exception to raise from ``get()``.
+
+        Returns:
+            The stub session the lookup will use, for post-run assertions.
+
+        """
+        session = _StubSession(outcome)
+        monkeypatch.setattr(
+            mam_api.aiohttp, "ClientSession", lambda **_kwargs: session, raising=True
+        )
+        return session
+
+    return install
+
+
+async def test_returns_the_trimmed_body_on_a_200(stub_session: Any) -> None:
+    """Return the response body, stripped, when the provider answers 200."""
+    session = stub_session(_StubResponse(" 203.0.113.7\n", 200))
+
+    result = await mam_api.get_proxied_public_ip(PROXY_CFG)
+
+    assert result == "203.0.113.7"
+    assert session.requests == [(IPIFY_URL, PROXY_URL)]
+
+
+async def test_returns_none_on_a_non_200(stub_session: Any) -> None:
+    """Return None, without logging, when the provider answers a non-200 status."""
+    session = stub_session(_StubResponse("service unavailable", 503))
+
+    result = await mam_api.get_proxied_public_ip(PROXY_CFG)
+
+    assert result is None
+    assert session.requests == [(IPIFY_URL, PROXY_URL)]
+
+
+async def test_warns_and_returns_none_when_the_request_raises(
+    caplog: pytest.LogCaptureFixture, stub_session: Any
+) -> None:
+    """Log a warning and return None when the proxied request raises."""
+    stub_session(aiohttp.ClientError("proxy refused"))
+
+    with caplog.at_level(logging.WARNING, logger=mam_api.__name__):
+        result = await mam_api.get_proxied_public_ip(PROXY_CFG)
+
+    assert result is None
+    assert "[get_proxied_public_ip] Failed: proxy refused" in caplog.text
+
+
+async def test_returns_none_without_a_request_when_no_proxy_is_configured(
+    stub_session: Any,
+) -> None:
+    """Return None before any request when the config resolves to no proxy."""
+    session = stub_session(_StubResponse("203.0.113.7", 200))
+
+    result = await mam_api.get_proxied_public_ip({})
+
+    assert result is None
+    assert session.requests == []


### PR DESCRIPTION
## Summary

`get_proxied_public_ip` in `backend/mam_api.py` nests two `try` blocks whose handlers are character-for-character identical apart from a comment. The outer one cannot fire, so it is deleted and its body dedented.

No user-visible behaviour changes.

## Why the outer handler is unreachable

Two independent reasons, either sufficient on its own.

The only statement between the outer `try` and the inner one is the `proxy_url` assignment: two `dict.get` calls and an `isinstance`, on a value the `if not proxies: return None` guard immediately above has already proven truthy. None of the three can raise.

Everything after that point is inside an inner `try` whose `except Exception` already swallows every exception and returns, so nothing propagates outward regardless.

The comment the outer handler carried, `# Defensive: preserve original behavior on unexpected errors`, goes with the handler.

## A side effect worth noting

Once dedented, the `proxy_url` assignment fits on one line and `ruff format` collapses it. The result is byte-identical to the same idiom already at `mam_api.py:66` in `get_proxied_public_ip_and_asn` and at `:256` in `get_mam_seen_ip_info`. The wrapped form was the odd one out, and it was wrapped only because of the extra indentation the outer `try` imposed.

## Tests

No test in the suite imported `backend.mam_api` at all, so this adds `tests/backend/test_mam_api.py`. Since the change is behaviour-preserving, these are *characterising* tests rather than regression tests: they were written and confirmed passing against the **unmodified** function first, then re-run unchanged after the edit. Four cases against a substituted `aiohttp.ClientSession`:

- 200 returns the body, stripped, and requests `https://api.ipify.org` through the resolved proxy URL
- non-200 falls through to the tail `return None`, without logging
- a raising request logs `[get_proxied_public_ip] Failed: %s` at WARNING and returns `None`
- an unproxied config returns `None` before any request is made

Each assertion was checked with a negative control: dropping the `.strip()`, forcing the status gate true, deleting the warning log, deleting the no-proxy guard, and passing `proxy=None` instead of `proxy_url` each fail exactly the test that covers them, so none of the four is a no-op.

## Docs

None go stale. `docs/CHANGELOG.md` is the only file outside `backend/` that mentions `mam_api`, and it describes `classify_mam_response()`, which is untouched. Nothing references `get_proxied_public_ip`.

## Validation

Run in a local Python 3.13.15 / Node 24.19.0 environment against `b46ad3cc0`:

```
./scripts/lint.sh    # 16/16 prek hooks pass, npm audit clean, vite build clean
./scripts/test.sh    # Backend pytest PASS, Frontend Playwright E2E PASS
```

Backend line coverage moves 37.0% to 37.6%, branch coverage 22.1% to 22.6%.
