### PR TITLE
fix(perk_automation): stop sending a stale User-Agent on upload credit

### DIFF
--- a/backend/perk_automation.py
+++ b/backend/perk_automation.py
@@ -14,6 +14,14 @@ from backend.utils import build_proxy_dict
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
+# Every bonusBuy.php purchase presents this one browser identity.
+_BONUS_HEADERS: dict[str, str] = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+    "Accept": "application/json, text/javascript, */*; q=0.01",
+    "Accept-Language": "en-US,en;q=0.5",
+    "Referer": "https://www.myanonamouse.net/store.php",
+}
+
 
 async def buy_upload_credit(
     gb: int, mam_id: str | None = None, proxy_cfg: dict[str, Any] | None = None
@@ -34,9 +42,6 @@ async def buy_upload_credit(
         url = f"https://www.myanonamouse.net/json/bonusBuy.php/?spendtype=upload&amount={gb}&_={timestamp}"
         cookies = {"mam_id": mam_id}
         proxies = None
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-        }
         if proxy_cfg is not None:
             proxies = build_proxy_dict(proxy_cfg)
             if proxies:
@@ -71,7 +76,7 @@ async def buy_upload_credit(
         async with (
             aiohttp.ClientSession(timeout=timeout) as session,
             session.get(
-                url, cookies=cookies, proxy=proxy_url, proxy_auth=proxy_auth, headers=headers
+                url, cookies=cookies, proxy=proxy_url, proxy_auth=proxy_auth, headers=_BONUS_HEADERS
             ) as resp,
         ):
             _logger.debug("[buy_upload_credit] Response: status=%s", resp.status)
@@ -117,12 +122,6 @@ async def buy_vip(
     params: dict[str, Any] = {"spendtype": "VIP", "duration": duration, "_": timestamp}
     cookies = {"mam_id": mam_id}
     proxies = None
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
-        "Accept": "application/json, text/javascript, */*; q=0.01",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Referer": "https://www.myanonamouse.net/store.php",
-    }
     if proxy_cfg is not None:
         proxies = build_proxy_dict(proxy_cfg)
         if proxies:
@@ -161,7 +160,7 @@ async def buy_vip(
                 cookies=cookies,
                 proxy=proxy_url,
                 proxy_auth=proxy_auth,
-                headers=headers,
+                headers=_BONUS_HEADERS,
             ) as resp,
         ):
             _logger.debug("[buy_vip] Response: status=%s", resp.status)
@@ -207,12 +206,6 @@ async def buy_wedge(
     url = f"https://www.myanonamouse.net/json/bonusBuy.php/?spendtype=wedges&source={method}&_={timestamp}"
     cookies = {"mam_id": mam_id}
     proxies = None
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
-        "Accept": "application/json, text/javascript, */*; q=0.01",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Referer": "https://www.myanonamouse.net/store.php",
-    }
     if proxy_cfg is not None:
         proxies = build_proxy_dict(proxy_cfg)
         if proxies:
@@ -246,7 +239,7 @@ async def buy_wedge(
         async with (
             aiohttp.ClientSession(timeout=timeout) as session,
             session.get(
-                url, cookies=cookies, proxy=proxy_url, proxy_auth=proxy_auth, headers=headers
+                url, cookies=cookies, proxy=proxy_url, proxy_auth=proxy_auth, headers=_BONUS_HEADERS
             ) as resp,
         ):
             _logger.debug("[buy_wedge] Response: status=%s", resp.status)

--- a/tests/backend/test_perk_automation.py
+++ b/tests/backend/test_perk_automation.py
@@ -1,0 +1,136 @@
+"""Backend perk automation tests for the headers the bonusBuy purchases send."""
+
+from types import TracebackType
+from typing import Any, Self
+
+import pytest
+
+from backend import perk_automation
+
+# The four fields a bonusBuy.php purchase presents together, in the order the
+# shared constant declares them.
+BONUS_HEADER_NAMES = ("User-Agent", "Accept", "Accept-Language", "Referer")
+
+# Not a session cookie. The stub transport sends nothing anywhere, and no real
+# mam_id is read, constructed, or logged by these tests.
+PLACEHOLDER_MAM_ID = "not-a-session-cookie"
+
+
+class _StubResponse:
+    """Stub ``aiohttp`` response replaying a successful purchase."""
+
+    status = 200
+
+    async def json(self) -> Any:
+        """Return the payload a successful purchase decodes to."""
+        return {"success": True}
+
+    async def __aenter__(self) -> Self:
+        """Enter the response context."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Exit the response context."""
+
+
+class _StubRequest:
+    """Stub request handle usable as an async context manager, as ``get()`` is."""
+
+    def __init__(self, response: _StubResponse) -> None:
+        """Bind the response this handle resolves to.
+
+        Args:
+            response: Response returned when the context is entered.
+
+        """
+        self._response = response
+
+    async def __aenter__(self) -> _StubResponse:
+        """Enter the underlying response context."""
+        return await self._response.__aenter__()
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Exit the underlying response context."""
+        await self._response.__aexit__(exc_type, exc, tb)
+
+
+class _StubSession:
+    """Stub ``aiohttp`` session recording the headers of every request made."""
+
+    def __init__(self) -> None:
+        """Start with no recorded requests."""
+        self.headers_sent: list[dict[str, str]] = []
+
+    def get(self, _url: str, *, headers: dict[str, str], **_kwargs: Any) -> _StubRequest:
+        """Record the request headers and hand back a successful response.
+
+        Args:
+            _url: Request URL, unused because no request leaves the process.
+            headers: Request headers, recorded for the assertions below.
+            **_kwargs: Cookies, proxy and proxy auth, none of which are asserted.
+
+        Returns:
+            A request handle resolving to a successful stub response.
+
+        """
+        self.headers_sent.append(headers)
+        return _StubRequest(_StubResponse())
+
+    async def __aenter__(self) -> Self:
+        """Enter the session context."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Exit the session context."""
+
+
+@pytest.fixture
+def bonus_buy_session(monkeypatch: pytest.MonkeyPatch) -> _StubSession:
+    """Replace the purchase transport with a double that records its headers."""
+    session = _StubSession()
+    monkeypatch.setattr(
+        perk_automation.aiohttp, "ClientSession", lambda **_kwargs: session, raising=True
+    )
+    return session
+
+
+async def _buy_one_of_each() -> None:
+    """Run every purchase the module offers, one call each."""
+    await perk_automation.buy_upload_credit(1, mam_id=PLACEHOLDER_MAM_ID)
+    await perk_automation.buy_vip(PLACEHOLDER_MAM_ID)
+    await perk_automation.buy_wedge(PLACEHOLDER_MAM_ID)
+
+
+async def test_every_purchase_sends_identical_headers(bonus_buy_session: _StubSession) -> None:
+    """Present one identity across the upload credit, VIP and wedge purchases."""
+    await _buy_one_of_each()
+
+    upload_credit, vip, wedge = bonus_buy_session.headers_sent
+    assert upload_credit == vip
+    assert vip == wedge
+
+
+async def test_every_purchase_sends_all_four_header_fields(
+    bonus_buy_session: _StubSession,
+) -> None:
+    """Send the whole header set, so a partial update cannot pass unnoticed."""
+    await _buy_one_of_each()
+
+    assert [tuple(headers) for headers in bonus_buy_session.headers_sent] == [
+        BONUS_HEADER_NAMES
+    ] * len(bonus_buy_session.headers_sent)


### PR DESCRIPTION
Three functions in `backend/perk_automation.py` GET the same endpoint, `https://www.myanonamouse.net/json/bonusBuy.php/`, and they identify as two different browsers. `buy_vip` and `buy_wedge` send a byte-identical four-header dict. `buy_upload_credit` sends one header, with an older Chrome version string, and none of the other three.

That the two newer dicts are byte-identical to each other is what makes the third an oversight rather than a choice, and git history says the same thing from the other direction: `bfe53a738` (2025-08-06) wrote `buy_upload_credit`'s lone header, and `4a09e33dd` (2025-08-07) added the four-header dict to both `buy_vip` and `buy_wedge` without touching `buy_upload_credit`. `4a09e33dd` updated two of the three call sites the day after the third was written, and the third was never revisited.

**The claim, and its limit.** The claim is that the three calls are inconsistent and that the inconsistency is unintentional. It is **not** a claim that MaM treats the upload-credit call differently as a result: nothing here was verified against a live MaM session, and nothing below should be read as "rejected", "throttled" or "flagged".

## Behaviour change, declared

This is a live change to the upload-credit request:

- its `User-Agent` changes from `Chrome/120.0.0.0` to `Chrome/139.0.0.0`;
- it gains `Accept: application/json, text/javascript, */*; q=0.01`;
- it gains `Accept-Language: en-US,en;q=0.5`;
- it gains `Referer: https://www.myanonamouse.net/store.php`.

`buy_vip` and `buy_wedge` are unaffected. For them the new `_BONUS_HEADERS` constant is a substitution of an identical value, checkable by inspection against the diff, which localises the risk of this change to exactly one of the three functions.

Unification is onto the four-header form rather than away from it: dropping the three extra headers from `buy_vip` and `buy_wedge` would change two working calls to match one that was never updated, on no evidence about which form the server prefers. This changes one call to match two, and the two are the ones someone last touched deliberately.

## Tests

`tests/backend/test_perk_automation.py` is new; the module had no test file, so this coverage is net-new. Two tests assert that all three purchase functions send identical headers and that each sends all four named fields, so a future partial update fails the same way this one would have. The aiohttp session is stubbed, no request leaves the process, and no session cookie, `mam_id` or runtime config is read.

The tests were verified against the defect: with the `buy_upload_credit` substitution reverted and the other two left on the constant, both fail, the first naming the `User-Agent` mismatch and the three missing fields.

## Docs

None apply. `rg -n 'User-Agent|bonusBuy' docs/ README.md AGENTS.md` returns nothing, and so does the same search run fold-insensitively. The nearest text is `docs/troubleshooting.md:162`, which documents purchase costs rather than transport and stays accurate.

## Validation

- `./scripts/lint.sh` clean (16/16 hooks, frontend audit, production bundle build).
- `./scripts/test.sh` clean: backend pytest PASS, Playwright E2E PASS.

No deployment or data-compatibility notes: no configuration, schema or persisted file is touched.
