### PR TITLE
refactor(proxy_config): delete the exception handler no call in its body can reach

### DIFF
--- a/backend/proxy_config.py
+++ b/backend/proxy_config.py
@@ -29,15 +29,12 @@ def resolve_proxy_from_session_cfg(cfg: dict[str, Any]) -> dict[str, Any] | None
     proxy = cfg.get("proxy", {})
     # Rate-limit debug logs to avoid flooding when this resolver is called frequently
     log_key = None
-    try:
-        if isinstance(proxy, dict) and proxy.get("label"):
-            log_key = f"label:{proxy.get('label')}"
-        elif isinstance(proxy, dict) and proxy.get("host"):
-            log_key = f"inline:{proxy.get('host')}"
-        else:
-            log_key = "no_proxy"
-    except Exception:
-        log_key = "resolve_unknown"
+    if isinstance(proxy, dict) and proxy.get("label"):
+        log_key = f"label:{proxy.get('label')}"
+    elif isinstance(proxy, dict) and proxy.get("host"):
+        log_key = f"inline:{proxy.get('host')}"
+    else:
+        log_key = "no_proxy"
     now = time.monotonic()
     last = _last_resolve_log_time.get(log_key, 0.0)
     if now - last >= _resolve_log_min_interval:

--- a/tests/backend/test_proxy_config.py
+++ b/tests/backend/test_proxy_config.py
@@ -1,6 +1,7 @@
 """Backend tests for proxy configuration helpers."""
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -34,3 +35,36 @@ def test_load_proxies_rejects_non_mapping_yaml(
 
     with pytest.raises(YamlStoreError):
         proxy_config.load_proxies()
+
+
+def test_resolve_proxy_returns_the_labelled_proxy(temp_proxy_path: Path) -> None:
+    """Resolve a labelled proxy through proxies.yaml."""
+    temp_proxy_path.write_text("work:\n  host: proxy.internal\n  port: 8080\n", encoding="utf-8")
+
+    resolved = proxy_config.resolve_proxy_from_session_cfg({"proxy": {"label": "work"}})
+
+    assert resolved == {"host": "proxy.internal", "port": 8080}
+
+
+def test_resolve_proxy_returns_the_inline_proxy() -> None:
+    """Return a legacy inline proxy config unchanged."""
+    inline = {"host": "proxy.internal", "port": 8080}
+
+    resolved = proxy_config.resolve_proxy_from_session_cfg({"proxy": inline})
+
+    assert resolved == inline
+
+
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        {},
+        {"proxy": {}},
+        {"proxy": {"label": "", "host": ""}},
+        {"proxy": None},
+        {"proxy": "not-a-mapping"},
+    ],
+)
+def test_resolve_proxy_returns_none_when_neither_shape_applies(cfg: dict[str, Any]) -> None:
+    """Return None for every session config that is neither labelled nor inline."""
+    assert proxy_config.resolve_proxy_from_session_cfg(cfg) is None


### PR DESCRIPTION
`backend/proxy_config.py` guards the log-key computation in `resolve_proxy_from_session_cfg` with an `except Exception:` that nothing in its `try` can enter, so `log_key = "resolve_unknown"` is unreachable. This deletes the handler and adds the first direct test coverage of the function.

## Why the handler is dead

The guarded body is two `isinstance` calls, four `dict.get` calls and two f-strings:

```python
log_key = None
try:
    if isinstance(proxy, dict) and proxy.get("label"):
        log_key = f"label:{proxy.get('label')}"
    elif isinstance(proxy, dict) and proxy.get("host"):
        log_key = f"inline:{proxy.get('host')}"
    else:
        log_key = "no_proxy"
except Exception:
    log_key = "resolve_unknown"
```

`isinstance` against `dict` cannot raise and `dict.get` cannot raise. The only calls that could are `__bool__` on the truthiness tests and `__format__` on the f-strings, against the `label` and `host` values. Those values come from a closed set: every one of the eighteen call sites in `app.py`, `automation.py` and `api_automation.py` passes a `cfg` from `config.load_session`, which returns either `yaml.safe_load` output (`yaml_store.load_yaml_file`) or the module's own `get_default_config` default, whose `proxy` entry is `{"host": "", "port": 0, "username": "", "password": ""}`. `__bool__` and `__format__` are total for every type in that set.

## Method, and what would falsify it

This is an argument from the guarded call set plus that value domain, checked by an executed probe rather than asserted. `yaml.SafeConstructor` was enumerated rather than recalled: it registers twelve tags producing **eleven** distinct types (`str`, `int`, `float`, `bool`, `NoneType`, `list`, `dict`, `date`, `datetime`, `bytes` via `!!binary`, `set` via `!!set`). The real function was then called 55 times, with each of those eleven types placed in three positions — as `proxy` itself, as `proxy["label"]`, and as `proxy["host"]`, in truthy and falsy variants where they exist — plus a `cfg` with no `proxy` key. `_last_resolve_log_time` was inspected after each call, since a fired handler is observable as a `"resolve_unknown"` key. It fired **zero** times.

Two negative controls confirm the probe is not a no-op and name exactly what would falsify the claim: a value whose `__bool__` raises, and one whose `__format__` raises, each fired the handler. Any call reachable from the `try` body that can raise would break the argument; nothing `safe_load` can construct is such a call.

A branch-coverage run against the unmodified file agrees, reporting the handler lines as the only unreached statements in the function:

```text
Name                      Stmts   Miss Branch BrPart  Cover   Missing
backend/proxy_config.py      56      3     16      2    93%   39-40, 54->61, 68->71, 96
```

`54->61` and `68->71` are the debug-log throttle re-entry branches and `96` is `save_proxies`; none is in scope here.

## No behaviour change

Deleting an unreachable handler cannot alter any execution. The three new tests were run against the file **with the handler still present** and against the file with it deleted, and pass identically both ways. They are exhaustiveness coverage for the `if`/`elif`/`else`, not a regression gate — the gate for a dead-code deletion is the argument above.

## Tests

`resolve_proxy_from_session_cfg` had no direct coverage: `tests/backend/test_proxy_config.py` only exercised `load_proxies`, and the one other reference in the suite monkeypatches the function away. Added one case per arm — a labelled proxy resolved through `proxies.yaml`, a legacy inline proxy returned unchanged, and a parametrized set of configs that are neither, each expected to return `None`. Those three arms being exhaustive is the same fact that makes the handler dead.

## Deliberately left alone

- `log_key = None` on the line above. It is separately dead, because all three arms assign `log_key` and there is no fall-through, but that is a different defect and a different change. Deleting the handler makes its deadness obvious rather than argued; it still stands here.
- The three later `isinstance(proxy, dict)` re-tests. The argument above depends on the first two being `isinstance` calls, so collapsing them belongs in its own change.
- The throttled `_logger.debug` blocks, the repeated `time.monotonic()` reads, `PROXIES_PATH`, and the `async` question for this function.

`pyproject.toml` is untouched. `BLE001` is currently in `ignore`, so this site does not fire today; the deletion is correct either way, and it removes one site to argue whenever that entry goes. Worth noting for that future change: the correct narrowing tuple here is *empty*, and a handler for no exceptions is a deleted one rather than a narrower one, so mechanically rewriting every `BLE001` site into an explicit tuple would produce either `except ():` or an invented exception type the body cannot raise.

## Docs

None apply. `proxy_config`, `resolve_proxy`, and `resolve_unknown` return no case-insensitive match in `docs/`, `README.md` or `AGENTS.md`, and the module docstring describes loading, saving and the inline compatibility helper without mentioning error handling, so it stays true. No new helper, so no new docstring obligation.

## Validation

`./scripts/lint.sh` and `./scripts/test.sh` both clean.
