### PR TITLE
fix(api_automation): return 400 instead of 500 for a non-numeric VIP week count

### DIFF
--- a/backend/api_automation.py
+++ b/backend/api_automation.py
@@ -287,8 +287,9 @@ async def manual_vip(request: Request) -> dict[str, Any]:
 
     Expects a JSON body with the following fields:
     - label: session label (required)
-    - weeks: number of weeks for VIP (optional, defaults to 4). Special
-      values like "max" or "90" are treated as max-duration purchases.
+    - weeks: whole number of weeks for VIP, as a number or a string
+      (optional, defaults to 4). "max" and 90 are treated as max-duration
+      purchases.
 
     The endpoint performs the VIP purchase, records an event, and attempts
     notifications. Returns a dict with a "success" boolean and purchase
@@ -296,7 +297,8 @@ async def manual_vip(request: Request) -> dict[str, Any]:
 
     Raises:
         HTTPException: If the required `label` field is missing from the
-            request JSON.
+            request JSON, or if `weeks` is neither "max" nor a whole number
+            of weeks.
 
     """
     data = await request.json()
@@ -304,6 +306,19 @@ async def manual_vip(request: Request) -> dict[str, Any]:
     weeks = data.get("weeks", 4)
     if not label:
         raise HTTPException(status_code=400, detail="Session label required.")
+    invalid_weeks = (
+        f"Invalid VIP week count: {weeks!r}. Valid values are a whole number of weeks or 'max'."
+    )
+    if isinstance(weeks, bool) or not isinstance(weeks, int | str):
+        raise HTTPException(status_code=400, detail=invalid_weeks)
+    # "max" is MAM's 90-week purchase, priced variably rather than per week
+    if isinstance(weeks, str) and weeks.lower() == "max":
+        weeks_int = 90
+    else:
+        try:
+            weeks_int = int(weeks)
+        except ValueError:
+            raise HTTPException(status_code=400, detail=invalid_weeks) from None
     cfg = load_session(label)
     if cfg is None:
         _logger.warning("[ManualVIP] Session '%s' not found or not configured.", label)
@@ -311,13 +326,13 @@ async def manual_vip(request: Request) -> dict[str, Any]:
     mam_id = cfg.get("mam", {}).get("mam_id", "")
     proxy_cfg = resolve_proxy_from_session_cfg(cfg)
     now = datetime.now(UTC)
-    is_max = str(weeks).lower() in ["max", "90"]
+    is_max = weeks_int == 90
     # --- Enforce minimum points guardrail (prevent spend below minimum) ---
     # Max/90-week VIP has variable cost; guardrail is skipped for that case
     enforce_min_pts = cfg.get("perk_automation", {}).get("enforce_min_points_guardrail", False)
     session_min_points = cfg.get("perk_automation", {}).get("min_points")
     if enforce_min_pts and session_min_points is not None and not is_max:
-        purchase_cost = _VIP_POINTS_COST.get(int(weeks)) if int(weeks) in _VIP_POINTS_COST else None
+        purchase_cost = _VIP_POINTS_COST.get(weeks_int)
         if purchase_cost is not None:
             status = await get_status(mam_id=mam_id, proxy_cfg=proxy_cfg)
             current_points = status.get("points", 0) if isinstance(status, dict) else 0
@@ -337,7 +352,7 @@ async def manual_vip(request: Request) -> dict[str, Any]:
                         "event_type": "manual",
                         "trigger": "manual",
                         "purchase_type": "vip",
-                        "amount": weeks,
+                        "amount": weeks_int,
                         "details": {"points_before": current_points},
                         "result": "blocked",
                         "status_message": f"Manual VIP purchase blocked: {guardrail_reason}",
@@ -401,10 +416,12 @@ async def manual_vip(request: Request) -> dict[str, Any]:
             )
         return {"success": success, **result}
     # For 4 or 8 weeks, just send the value as string
-    result = await buy_vip(mam_id, duration=str(weeks), proxy_cfg=proxy_cfg)
+    result = await buy_vip(mam_id, duration=str(weeks_int), proxy_cfg=proxy_cfg)
     success = result.get("success", False)
     status_message = (
-        f"Purchased VIP ({weeks} weeks)" if success else f"VIP purchase failed ({weeks} weeks)"
+        f"Purchased VIP ({weeks_int} weeks)"
+        if success
+        else f"VIP purchase failed ({weeks_int} weeks)"
     )
     event = {
         "timestamp": now.isoformat(),
@@ -412,7 +429,7 @@ async def manual_vip(request: Request) -> dict[str, Any]:
         "event_type": "manual",
         "trigger": "manual",
         "purchase_type": "vip",
-        "amount": weeks,
+        "amount": weeks_int,
         "details": {},
         "result": "success" if success else "failed",
         "error": result.get("error") if not success else None,
@@ -425,23 +442,23 @@ async def manual_vip(request: Request) -> dict[str, Any]:
                 event_type="manual_purchase_success",
                 label=label,
                 status="SUCCESS",
-                message=f"Manual VIP purchase succeeded: {weeks} weeks",
-                details={"weeks": weeks},
+                message=f"Manual VIP purchase succeeded: {weeks_int} weeks",
+                details={"weeks": weeks_int},
             )
         else:
             await notify_event(
                 event_type="manual_purchase_failure",
                 label=label,
                 status="FAILED",
-                message=f"Manual VIP purchase failed: {weeks} weeks",
-                details={"weeks": weeks, "error": result.get("error")},
+                message=f"Manual VIP purchase failed: {weeks_int} weeks",
+                details={"weeks": weeks_int, "error": result.get("error")},
             )
     except Exception:
         _logger.debug("[ManualVIP] Manual VIP purchase notification failed.")
     if success:
         _logger.info(
             "[ManualVIP] Purchase: VIP (%s weeks) for session '%s' succeeded.",
-            weeks,
+            weeks_int,
             label,
         )
     else:
@@ -451,7 +468,7 @@ async def manual_vip(request: Request) -> dict[str, Any]:
         )
         _logger.warning(
             "[ManualVIP] Purchase: VIP (%s weeks) for session '%s' FAILED. Error: %s",
-            weeks,
+            weeks_int,
             label,
             error_val,
         )

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -203,26 +203,35 @@ Update automation settings for a session.
 }
 ```
 
-### POST `/api/purchase/{label}/{item_type}`
-Manually trigger a purchase.
+### POST `/api/automation/upload_auto`
+Manually trigger an upload credit purchase.
 
-**Parameters:**
-- `label` (path): Session label/name
-- `item_type` (path): One of `upload`, `vip`
-
-**Request Body (for upload credit):**
+**Request Body:**
 ```json
 {
-  "gb": 50
+  "label": "session-name",
+  "amount": 50
 }
 ```
 
-**Request Body (for VIP):**
+- `label` is required; a missing label returns `400`.
+- `amount` is a number of GB and must be `50` or `100`; any other value returns `400`.
+
+### POST `/api/automation/vip`
+Manually trigger a VIP purchase.
+
+**Request Body:**
 ```json
 {
+  "label": "session-name",
   "weeks": 4
 }
 ```
+
+- `label` is required; a missing label returns `400`.
+- `weeks` is a whole number of weeks, sent as a number or a string, and defaults
+  to `4`. `"max"` and `90` both buy the max duration. Any other value returns
+  `400`.
 
 ---
 

--- a/tests/backend/integration/test_automation_vip.py
+++ b/tests/backend/integration/test_automation_vip.py
@@ -1,0 +1,103 @@
+"""Backend integration coverage for the manual VIP purchase route."""
+
+from typing import Any
+
+from httpx import AsyncClient
+import pytest
+
+from backend import api_automation, config
+
+
+def _save_vip_session(label: str, *, guardrail: bool) -> None:
+    """Persist a session with the minimum-points guardrail on or off."""
+    config.save_session(
+        {
+            "label": label,
+            "mam": {"mam_id": "cookie"},
+            "perk_automation": {
+                "enforce_min_points_guardrail": guardrail,
+                "min_points": 1000,
+            },
+        }
+    )
+
+
+@pytest.fixture
+def purchases(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record the duration of every purchase, leaving no route to MAM open."""
+    durations: list[str] = []
+
+    async def fake_buy_vip(
+        _mam_id: str, duration: str = "max", proxy_cfg: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        durations.append(duration)
+        return {"success": True}
+
+    async def unblocked_status(
+        mam_id: str, proxy_cfg: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        return {"points": 1_000_000}
+
+    monkeypatch.setattr(api_automation, "buy_vip", fake_buy_vip)
+    monkeypatch.setattr(api_automation, "get_status", unblocked_status)
+    return durations
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("guardrail", [True, False])
+@pytest.mark.parametrize("weeks", ["abc", None, 4.5, True])
+async def test_unparseable_weeks_is_rejected_without_purchasing(
+    api_client: AsyncClient,
+    purchases: list[str],
+    guardrail: bool,
+    weeks: object,
+) -> None:
+    """A week count that is not a whole number is a client error on every session."""
+    _save_vip_session("seedbox", guardrail=guardrail)
+
+    response = await api_client.post(
+        "/api/automation/vip", json={"label": "seedbox", "weeks": weeks}
+    )
+
+    assert response.status_code == 400
+    assert repr(weeks) in response.json()["detail"]
+    assert purchases == []
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(("weeks", "duration"), [(4, "4"), ("8", "8"), ("max", "max"), (90, "max")])
+async def test_accepted_weeks_reach_the_purchase(
+    api_client: AsyncClient,
+    purchases: list[str],
+    weeks: object,
+    duration: str,
+) -> None:
+    """The accepted domain still reaches MAM, with "max" and 90 weeks equivalent."""
+    _save_vip_session("seedbox", guardrail=False)
+
+    response = await api_client.post(
+        "/api/automation/vip", json={"label": "seedbox", "weeks": weeks}
+    )
+
+    assert response.json() == {"success": True}
+    assert purchases == [duration]
+
+
+@pytest.mark.integration
+async def test_guardrail_blocks_a_priced_purchase(
+    api_client: AsyncClient, purchases: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A parsed week count still prices the purchase against the points guardrail."""
+
+    async def fake_status(mam_id: str, proxy_cfg: dict[str, Any] | None = None) -> dict[str, Any]:
+        return {"points": 5_500}
+
+    monkeypatch.setattr(api_automation, "get_status", fake_status)
+    _save_vip_session("seedbox", guardrail=True)
+
+    response = await api_client.post("/api/automation/vip", json={"label": "seedbox", "weeks": "4"})
+
+    body = response.json()
+    assert body["success"] is False
+    assert "minimum points" in body["error"]
+    assert purchases == []


### PR DESCRIPTION
`POST /api/automation/vip` accepts `weeks` straight from the request body and converts it with `int()` deep inside the handler, so a non-numeric value is a server error rather than a client error, and which failure you get depends on the session's configuration.

With `enforce_min_points_guardrail` enabled and `min_points` set, `{"label": "...", "weeks": "abc"}` reaches `_VIP_POINTS_COST.get(int(weeks))`, raises `ValueError`, and answers **500** (nothing in `manual_vip` catches it: the first `except` is well past that line). With the guardrail off, the same request skips that line entirely and sails through to `buy_vip(mam_id, duration=str(weeks), ...)`, issuing a real authenticated request to MAM with `duration="abc"` and answering 200.

The two sibling routes do not behave this way: `manual_upload_credit` validates `amount` against its domain and raises a 400, and `manual_wedge` returns an error dict for an unsupported method. `manual_vip` was the only one of the three with no validation on its perk-specific field.

## The change

`weeks` is parsed once at the top of the handler, in the shape `manual_upload_credit` already uses. It accepts a whole number of weeks as a number or a string, plus `"max"` (case-insensitive), which is MAM's 90-week variable-cost purchase. Anything else raises `HTTPException(status_code=400, ...)` naming the value received and the accepted domain. The parsed integer is bound once and used for the `is_max` test, the guardrail pricing, and the purchase itself.

Validating at the top rather than wrapping the `int()` in a `try` is deliberate: the narrow fix would leave the contract configuration-dependent, returning 400 from a guardrail-enabled session and still firing a garbage purchase request from a guardrail-disabled one.

## Behaviour changes

1. **A `weeks` value that is not a whole number or `"max"` now returns 400.** On the guardrail path that replaces a 500. On the guardrail-disabled path it replaces a live authenticated purchase request to MAM carrying the malformed value; that is the larger change in practice. Values that were never whole numbers of weeks are covered by the same guard: `null`, `true`, and `4.5` previously went upstream as `"None"`, `"True"` and `"4.5"` (or raised `TypeError`) and now return 400.
2. **Numeric spellings of 90 all route to the max purchase.** `is_max` was a string test against `["max", "90"]`, so `90` and `"90"` were max but `"090"` was sent as a 90-week purchase with no pricing. The test is now `weeks_int == 90`.
3. **The purchase and its event log carry the parsed integer**, so `"04"` reaches MAM as `4` and the event's `amount` is a number rather than whatever the client sent.

The UI is unaffected: `PerkAutomationCard.jsx` sends `Number(vipWeeks)` from a fixed 4 / 8 / 90 selection, all of which are still accepted.

Also collapsed on the line being rewritten: `_VIP_POINTS_COST.get(int(weeks)) if int(weeks) in _VIP_POINTS_COST else None` is `_VIP_POINTS_COST.get(weeks_int)`. `dict.get` already returns `None` for a missing key, so the conditional cost an extra conversion and an extra lookup to answer a question `.get` had answered.

## Tests

`tests/backend/integration/test_automation_vip.py` is new; no test covered any manual-purchase route before. It goes through the ASGI boundary with `buy_vip` and `get_status` stubbed, so no test can reach MAM:

- unparseable `weeks` (`"abc"`, `null`, `4.5`, `true`) against a session with the guardrail on **and** one with it off, asserting 400 and that no purchase was attempted;
- `4`, `"8"`, `"max"` and `90` still reach the purchase with durations `"4"`, `"8"`, `"max"`, `"max"`;
- a guardrail-enabled session still prices a parsed week count and blocks the purchase.

Each rejection case was verified against the unfixed code: `"abc"` with the guardrail on fails with `ValueError: invalid literal for int() with base 10: 'abc'` at the pricing line, `null` with `TypeError`, and with the guardrail off the same request returns 200 with `buy_vip` recorded as called with `duration='abc'`.

## Docs

`docs/api-reference.md` documented manual purchases under `POST /api/purchase/{label}/{item_type}`, which does not exist: `app.openapi()["paths"]` lists `/api/automation/upload_auto`, `/api/automation/vip` and `/api/automation/wedge`. That section now names the two routes it was describing, with their real bodies (`label` plus `amount` for upload credit, `label` plus `weeks` for VIP) and their 400 responses. `manual_vip`'s docstring gains the `weeks` domain and the new `Raises` case. `README.md` and `AGENTS.md` mention neither the route nor the field and need no change.

## Validation

`./scripts/lint.sh` and `./scripts/test.sh` both clean (94 backend tests, 5 Playwright E2E).
