### PR TITLE
refactor(notify): stop defaulting event rules to an incomplete channel list

### DIFF
--- a/backend/notifications_backend.py
+++ b/backend/notifications_backend.py
@@ -300,7 +300,7 @@ async def notify_event(
     """
     cfg = load_notify_config()
     event_rules = cfg.get("event_rules", {})
-    rule = event_rules.get(event_type, {"email": False, "webhook": False, "apprise": False})
+    rule = event_rules.get(event_type, {})
     # Check if this notification event is explicitly disabled via the 'enabled' flag
     # If enabled is False, don't send any notifications regardless of channel settings
     if rule.get("enabled") is False:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -365,11 +365,15 @@ Get current notification configuration.
   "event_rules": {
     "automation_success": {
       "email": false,
-      "webhook": true
+      "webhook": true,
+      "apprise": false,
+      "pushover": false
     },
     "automation_failure": {
-      "email": true, 
-      "webhook": true
+      "email": true,
+      "webhook": true,
+      "apprise": false,
+      "pushover": true
     }
   }
 }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -300,9 +300,13 @@ event_rules:
   automation_success:
     email: true     # Enable email notifications
     webhook: true   # Enable webhook notifications
+    apprise: false  # Enable Apprise notifications
+    pushover: false # Enable Pushover notifications
   automation_failure:
     email: true
     webhook: true
+    apprise: false
+    pushover: true
 ```
 
 ---

--- a/tests/backend/test_notifications_backend.py
+++ b/tests/backend/test_notifications_backend.py
@@ -1,0 +1,127 @@
+"""Backend tests for notification event-rule dispatch."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from backend import notifications_backend
+
+# The channels notify_event dispatches on, in the order it tries them.
+CHANNELS = ("webhook", "email", "apprise", "pushover")
+
+# Stand-in for every credential the channel configuration needs. Referencing a
+# name rather than repeating a literal keeps flake8-bandit quiet without a noqa.
+PLACEHOLDER = "placeholder"
+
+# Enough configuration for all four channels, so that a rule enabling any one of
+# them reaches its sender. Without this a silent dispatch would be ambiguous
+# between the rule stopping it and the channel being unconfigured.
+CHANNEL_CONFIG: dict[str, Any] = {
+    "webhook_url": "https://webhook.invalid/hook",
+    "smtp": {
+        "host": "smtp.invalid",
+        "port": 587,
+        "username": "sender@invalid",
+        "password": PLACEHOLDER,
+        "to_email": "recipient@invalid",
+    },
+    "apprise": {
+        "url": "https://apprise.invalid",
+        "notify_url_string": "json://localhost",
+    },
+    "pushover": {"user_key": PLACEHOLDER, "api_token": PLACEHOLDER},
+}
+
+
+@pytest.fixture
+def notify_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point notification configuration at an isolated file.
+
+    Args:
+        tmp_path: Directory holding the notification configuration.
+        monkeypatch: Fixture used to redirect the module-level path.
+
+    Returns:
+        The path the module now loads its configuration from.
+
+    """
+    path = tmp_path / "notify.yaml"
+    monkeypatch.setattr(notifications_backend, "NOTIFY_CONFIG_PATH", path)
+    return path
+
+
+@pytest.fixture
+def dispatched(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Replace every channel sender with a stub that records the channel.
+
+    Args:
+        monkeypatch: Fixture used to replace the four senders.
+
+    Returns:
+        The channels reached, appended in dispatch order.
+
+    """
+    sent: list[str] = []
+
+    async def webhook(*_args: Any, **_kwargs: Any) -> bool:
+        """Record a webhook dispatch and report success."""
+        sent.append("webhook")
+        return True
+
+    def smtp(*_args: Any, **_kwargs: Any) -> bool:
+        """Record an SMTP dispatch and report success."""
+        sent.append("email")
+        return True
+
+    async def apprise(*_args: Any, **_kwargs: Any) -> bool:
+        """Record an Apprise dispatch and report success."""
+        sent.append("apprise")
+        return True
+
+    async def pushover(*_args: Any, **_kwargs: Any) -> bool:
+        """Record a Pushover dispatch and report success."""
+        sent.append("pushover")
+        return True
+
+    monkeypatch.setattr(notifications_backend, "send_webhook_notification", webhook)
+    monkeypatch.setattr(notifications_backend, "send_smtp_notification", smtp)
+    monkeypatch.setattr(notifications_backend, "send_apprise_notification", apprise)
+    monkeypatch.setattr(notifications_backend, "send_pushover_notification", pushover)
+    return sent
+
+
+def _write_notify_config(path: Path, event_rules: dict[str, Any]) -> None:
+    """Persist the fully configured channels alongside the given event rules.
+
+    Args:
+        path: Destination for the notification configuration.
+        event_rules: Mapping from event type to its per-channel rule.
+
+    """
+    config = CHANNEL_CONFIG | {"event_rules": event_rules}
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+
+@pytest.mark.parametrize("channel", CHANNELS)
+async def test_single_channel_rule_dispatches_only_that_channel(
+    notify_config: Path, dispatched: list[str], channel: str
+) -> None:
+    """Reach exactly the one channel a rule enables, for each of the four."""
+    _write_notify_config(notify_config, {"automation_failure": {channel: True}})
+
+    await notifications_backend.notify_event("automation_failure", message="check")
+
+    assert dispatched == [channel]
+
+
+async def test_event_type_without_a_rule_dispatches_nothing(
+    notify_config: Path, dispatched: list[str]
+) -> None:
+    """Stay silent on every channel for an event type no rule covers."""
+    _write_notify_config(notify_config, {"automation_success": dict.fromkeys(CHANNELS, True)})
+
+    await notifications_backend.notify_event("automation_failure", message="check")
+
+    assert dispatched == []


### PR DESCRIPTION
## Summary

`notify_event` supplies a fallback when an event type has no rule in `event_rules`:

```python
rule = event_rules.get(event_type, {"email": False, "webhook": False, "apprise": False})
```

That literal enumerates the notification channel set, and it enumerates it one short. The guard immediately below it tests four channels (`email`, `webhook`, `apprise`, `pushover`) and there are four dispatch arms, so the default has been describing a three-channel product since Pushover landed. This replaces it with `{}`, which is what the surrounding code already treats it as.

**This is not a behaviour change, and I want to be explicit about that.** `rule` is read nine times in `notify_event` and every read is a `.get()` in boolean context. From the old literal, `.get("enabled")` is `None` (the literal has no `enabled` key) and the four channel reads are `False, False, False, None`; from `{}` they are five `None`s. All falsy either way, so both take the same early `return` and the dispatch arms are unreachable under both. The default has never produced a bug, because it has never been read as data. It would the moment anyone reads `rule` positionally, iterates it, or hands it to a model — which is why it is worth retiring rather than widening.

The drift is datable. `git log -S` on the literal returns exactly one commit, `2a3dcd8d` ("Add apprise as notification option", #18), which wrote the three-channel form. `43e095c4` ("feat: add Pushover notification support", #48) widened the guard to four clauses and added the `if rule.get("pushover"):` arm, and left this line alone.

## Changes

**`backend/notifications_backend.py`** — one line: the default becomes `{}`.

**`tests/backend/test_notifications_backend.py`** (new) — `notify_event` had no test coverage at all before this (lines 301-397 were entirely unreported; the file was at 12%, now 41%). Five tests:

- `test_single_channel_rule_dispatches_only_that_channel`, parametrized over all four channels: a rule enabling exactly one channel reaches that sender and no other.
- `test_event_type_without_a_rule_dispatches_nothing`: an event type no rule covers sends on none of the four, with every channel fully configured so a silent result cannot be confused with an unconfigured channel.

The parametrize is what makes the silence test meaningful: it proves each of the four senders is reachable under the fixture's configuration, so an empty result can only mean the rule stopped the dispatch.

**`docs/api-reference.md`, `docs/troubleshooting.md`** — the same channel-set drift appears in two `event_rules` examples that show only `email` and `webhook`. Brought up to four. `docs/indexer-integrations.md` and `docs/prowlarr-integration.md` already showed all four. `README.md` and `AGENTS.md` never mention `event_rules`.

## Validation

- `./scripts/lint.sh` — clean, all 16 hooks pass.
- `./scripts/test.sh` — backend pytest PASS, Playwright E2E PASS.

Negative controls, since a passing test on an inert change proves little on its own:

| Control | Result |
| --- | --- |
| Restore the old literal | All 5 tests still pass — confirms the change is inert, as claimed above |
| Default read as data (`dict.fromkeys(CHANNELS, True)`) | `test_event_type_without_a_rule_dispatches_nothing` fails with all four dispatched |
| Drop the `pushover` clause from the guard (the `2a3dcd8d` drift shape) | The `[pushover]` parametrize case fails |

So neither new test fails against the pre-fix code, and that is the honest result: this retires a stale specification, it does not fix a live bug. What the tests do is pin the four-channel contract the deleted literal was pretending to state, so the next channel addition cannot repeat the drift silently.

## Out of scope

`notifications_backend.py` has other things worth a look that are deliberately not touched here, to keep the change scoped: the `SUCCESS`/`FAILED`-only status comparison at `:161-167`, the Apprise-mode validation that diverges across three sites, and the three separate `aiohttp.ClientTimeout` literals. Happy to open those separately if you'd like them.
