### PR TITLE
fix(port_monitor): log the public-IP override change the edit path never logs

### DIFF
--- a/backend/api_port_monitor.py
+++ b/backend/api_port_monitor.py
@@ -79,13 +79,6 @@ def update_stack(
     _logger.info("[PortMonitorStackAPI] Update requested for stack '%s'", name)
     if not stack:
         raise HTTPException(status_code=404, detail="Stack not found")
-    # Only log if something actually changed
-    changed = (
-        stack.primary_container != req.primary_container
-        or stack.primary_port != req.primary_port
-        or stack.secondary_containers != req.secondary_containers
-        or stack.interval != req.interval
-    )
     old_values = {
         "primary_container": stack.primary_container,
         "primary_port": stack.primary_port,
@@ -93,6 +86,15 @@ def update_stack(
         "interval": stack.interval,
         "public_ip": stack.public_ip,
     }
+    new_values = {
+        "primary_container": req.primary_container,
+        "primary_port": req.primary_port,
+        "secondary_containers": req.secondary_containers,
+        "interval": req.interval,
+        "public_ip": req.public_ip,
+    }
+    # Only log if something actually changed
+    changed = old_values != new_values
     stack.primary_container = req.primary_container
     stack.primary_port = req.primary_port
     stack.secondary_containers = req.secondary_containers
@@ -117,12 +119,7 @@ def update_stack(
                 "status_message": f"Stack '{name}' edited: primary={req.primary_container}:{req.primary_port}, secondaries={req.secondary_containers}, interval={req.interval} minutes.",
                 "details": {
                     "old": old_values,
-                    "new": {
-                        "primary_container": req.primary_container,
-                        "primary_port": req.primary_port,
-                        "secondary_containers": req.secondary_containers,
-                        "interval": req.interval,
-                    },
+                    "new": new_values,
                 },
                 "message": f"Stack '{name}' edited",
                 "level": "info",

--- a/tests/backend/test_port_monitor.py
+++ b/tests/backend/test_port_monitor.py
@@ -593,6 +593,31 @@ def test_config_mutation_rolls_back_on_save_failure(
     assert manager.stacks == [existing]
 
 
+def test_update_stack_logs_override_change_with_symmetric_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An override-only edit is logged, and both detail sides describe the same fields."""
+    stack = port_monitor.PortMonitorStack("x", "old", 80, ["secondary"], 60, "1.1.1.1")
+    events = Mock()
+    monkeypatch.setattr(api_port_monitor.port_monitor_manager, "get_stack", lambda _name: stack)
+    monkeypatch.setattr(api_port_monitor.port_monitor_manager, "save_stacks", Mock())
+    monkeypatch.setattr(api_port_monitor.port_monitor_manager, "recheck_stack", Mock())
+    monkeypatch.setattr(api_port_monitor, "append_ui_event_log", events)
+    request = api_port_monitor.UpdatePortMonitorStackRequest(
+        primary_container="old",
+        primary_port=80,
+        secondary_containers=["secondary"],
+        interval=60,
+        public_ip="2.2.2.2",
+    )
+
+    assert api_port_monitor.update_stack("x", request) == {"success": True}
+    events.assert_called_once()
+    details = events.call_args.args[0]["details"]
+    assert details["new"].keys() == details["old"].keys()
+    assert (details["old"]["public_ip"], details["new"]["public_ip"]) == ("1.1.1.1", "2.2.2.2")
+
+
 def test_update_stack_restores_values_on_save_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """The update endpoint leaves no unpersisted configuration in memory."""
     stack = port_monitor.PortMonitorStack("x", "old", 80, ["secondary"], 60, "1.1.1.1")

--- a/tests/backend/workflows/test_port_monitor_workflow.py
+++ b/tests/backend/workflows/test_port_monitor_workflow.py
@@ -41,6 +41,21 @@ async def test_port_monitor_create_edit_recheck_delete(
         51414,
         10,
     )
+    overridden = await api_client.put(
+        "/api/port-monitor/stacks?name=media",
+        json={
+            "primary_container": "vpn-new",
+            "primary_port": 51414,
+            "secondary_containers": ["client", "arr"],
+            "interval": 10,
+            "public_ip": "203.0.113.7",
+        },
+    )
+    assert overridden.json() == {"success": True}
+    assert (await api_client.get("/api/port-monitor/stacks")).json()[0][
+        "public_ip"
+    ] == "203.0.113.7"
+
     assert (await api_client.post("/api/port-monitor/stacks/recheck?name=media")).json() == {
         "success": True
     }
@@ -53,8 +68,14 @@ async def test_port_monitor_create_edit_recheck_delete(
     assert [event["event"] for event in events] == [
         "port_monitor_created",
         "port_monitor_edit",
+        "port_monitor_edit",
         "port_monitor_deleted",
     ]
+    override_details = events[2]["details"]
+    assert (override_details["old"]["public_ip"], override_details["new"]["public_ip"]) == (
+        None,
+        "203.0.113.7",
+    )
 
 
 @pytest.mark.workflow


### PR DESCRIPTION
## Summary

Changing **only** the Public IP Override on a port-monitor stack writes the config and emits no event. `update_stack` computes `changed` from four fields — `primary_container`, `primary_port`, `secondary_containers`, `interval` — and not `public_ip`. It then assigns `stack.public_ip = req.public_ip` and persists unconditionally, but gates the `port_monitor_edit` event on `changed`. The write happens; the log does not. The comment above it, "Only log if something actually changed", is false in that direction.

That path is reachable from the UI, not just the API. `PortMonitorCard.jsx`'s `handleSaveEdit` PUTs all five fields from a form whose Public IP field is independently editable, and the value is rendered back as "Public IP Override: …". A user can change it, see it change, and find nothing in the event log.

A second consequence of the same asymmetry: when an event *is* emitted, `details.old` carries five keys including `public_ip` while `details.new` carries four, so every `port_monitor_edit` row reads as though the edit cleared the override.

The fix builds `new_values` with the same five keys as `old_values`, computes `changed = old_values != new_values`, and uses that dict for `details.new`. Making the two sides one structure is what stops this class of drift recurring: a future field can no longer be added to one side alone.

## Behaviour changes, both intended

1. **A new event is emitted where none was before.** A `public_ip`-only edit now writes a `port_monitor_edit` row, visible in the UI event log. That is the defect being fixed.
2. **`details.new` gains a key.** The `port_monitor_edit` payload grows `public_ip` under `new`, making it symmetric with `old`.

Nothing else changes. An edit that alters none of the five fields still logs nothing, exactly as before.

## A trap for anyone touching this region later

The `changed = old_values != new_values` form is correct **only** with a five-key `new_values`. `old_values` gained `public_ip` in `9799b2ab9` (#69) to widen the rollback loop, not to widen `changed`. Pairing that five-key `old_values` with a four-key `new_values` makes the comparison unconditionally `True` and emits a `port_monitor_edit` on every update, changed or not.

This is not hypothetical: it was run deliberately as a negative control here, and the workflow test's four-event assertion **passed** under it while the payload assertion failed. Anyone reaching for the comparison form owes the five-key `new_values` that goes with it.

## Files touched

- `backend/api_port_monitor.py` — the fix.
- `tests/backend/workflows/test_port_monitor_workflow.py` — a `public_ip`-only PUT and the fourth `port_monitor_edit`, over the real ASGI boundary.
- `tests/backend/test_port_monitor.py` — a unit case pinning the `old`/`new` key symmetry.

No documentation change applies. `grep -rni port_monitor_edit docs/ README.md AGENTS.md` returns nothing, and `docs/features-guide.md` enumerates only `port_monitor_failure` and `port_monitor_restart` among port-monitor event types, so no user-facing doc describes this payload. `update_stack`'s docstring stays accurate. The stale item was the comment, and this change makes it true rather than deleting it.

## Validation

```
./scripts/lint.sh    # 16/16 hooks pass
./scripts/test.sh    # backend pytest PASS, Playwright E2E PASS (5 passed)
```

Both new tests were verified to fail without the fix, not merely to pass with it. Against unmodified `main` the workflow case fails on the missing fourth event (`At index 2 diff: 'port_monitor_deleted' != 'port_monitor_edit'`) and the unit case fails on `append_ui_event_log` never being called at all.

No deployment or data-compatibility concerns: the event log stores each event as JSON, so a payload growing a key needs no migration, and older rows remain readable.
