### PR TITLE
fix(frontend): type-check the javascript sources outside src/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,9 @@ for backend pytest and `coverage/frontend/` for Playwright E2E.
   accessible role and label locators; use a minimal `data-testid` only when no
   stable semantic locator exists.
 - Add container smoke coverage for production-image, startup, or persistence changes.
-- For frontend changes, at minimum run lint and TypeScript checks.
+- For frontend changes and for the JavaScript helpers under `scripts/`, at
+  minimum run lint and TypeScript checks. The frontend TypeScript project covers
+  both.
 - If a validation command cannot be run, note the exact reason in the handoff.
 
 ## Security and Privacy

--- a/frontend/e2e/support/coverage-fixture.js
+++ b/frontend/e2e/support/coverage-fixture.js
@@ -24,20 +24,31 @@ async function saveCoverage(page) {
   );
 }
 
-export const test = base.extend({
-  collectCoverage: [
-    async ({ page }, use) => {
-      const originalReload = page.reload.bind(page);
-      page.reload = async (...args) => {
-        await saveCoverage(page);
-        return originalReload(...args);
-      };
+export const test = base.extend(
+  /**
+   * @type {import('@playwright/test').Fixtures<
+   *   { collectCoverage: void },
+   *   {},
+   *   import('@playwright/test').PlaywrightTestArgs &
+   *     import('@playwright/test').PlaywrightTestOptions,
+   *   import('@playwright/test').PlaywrightWorkerArgs &
+   *     import('@playwright/test').PlaywrightWorkerOptions
+   * >}
+   */ ({
+    collectCoverage: [
+      async ({ page }, use) => {
+        const originalReload = page.reload.bind(page);
+        page.reload = async (...args) => {
+          await saveCoverage(page);
+          return originalReload(...args);
+        };
 
-      await use();
-      await saveCoverage(page);
-    },
-    { auto: true },
-  ],
-});
+        await use();
+        await saveCoverage(page);
+      },
+      { auto: true },
+    ],
+  }),
+);
 
 export { expect };

--- a/frontend/e2e/support/run-development-tests.mjs
+++ b/frontend/e2e/support/run-development-tests.mjs
@@ -14,6 +14,7 @@ rmSync(rawCoverageDir, { force: true, recursive: true });
 rmSync(reportDir, { force: true, recursive: true });
 mkdirSync(rawCoverageDir, { recursive: true });
 
+/** @type {NodeJS.ProcessEnv} */
 const playwrightEnv = { ...process.env, VITE_COVERAGE: 'true' };
 delete playwrightEnv.E2E_BASE_URL;
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.7",
         "@playwright/test": "^1.62.1",
+        "@types/node": "^24.13.3",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.7",
         "@vitejs/plugin-react": "^5.2.0",
@@ -2215,6 +2216,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -4215,6 +4226,13 @@
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.7",
     "@playwright/test": "^1.62.1",
+    "@types/node": "^24.13.3",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.7",
     "@vitejs/plugin-react": "^5.2.0",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,6 +11,6 @@
     "skipLibCheck": true,
     "strict": false
   },
-  "include": ["src/**/*"],
+  "include": ["**/*", "../scripts/**/*"],
   "exclude": ["node_modules", "build"]
 }

--- a/prek.toml
+++ b/prek.toml
@@ -109,7 +109,7 @@ id = "tsc"
 name = "tsc check"
 entry = "npm --prefix frontend run tsc"
 language = "system"
-files = "^frontend/"
+files = "^(frontend|scripts)/"
 types_or = ["ts", "tsx", "javascript", "json", "jsx"]
 pass_filenames = false
 


### PR DESCRIPTION
`frontend/tsconfig.json`'s `include` is `["src/**/*"]`, so ten tracked JavaScript sources are type-checked by nothing: `frontend/vite.config.mjs`, `frontend/playwright.config.js`, the six files under `frontend/e2e/`, and `scripts/coverage-summary.mjs` and `scripts/sync-biome-prek-hook.mjs`. The `tsc` hook in `prek.toml` selects `^frontend/`, so the two `scripts/` helpers were outside both the compiler's file set and the hook's selection.

This widens `include` to `["**/*", "../scripts/**/*"]`, widens the hook's `files` to `^(frontend|scripts)/`, declares `@types/node`, and fixes the two real diagnostics the widening exposes. The project stays at **0 errors**, now over **35 root files** instead of 25.

## What widening actually cost

Measured in four runs against the project-pinned `typescript@7.0.2`:

| Run | `include` | `@types/node` | Source fixes | Errors | Root files |
| --- | --- | --- | --- | --- | --- |
| baseline | `["src/**/*"]` | absent | — | 0 | 25 |
| A | `["**/*", "../scripts/**/*"]` | absent | no | 63 | 35 |
| B | `["**/*", "../scripts/**/*"]` | present | no | 2 | 35 |
| this PR | `["**/*", "../scripts/**/*"]` | present | yes | **0** | **35** |

**61 of the 63 are one missing `devDependency`.** Every one is `TS2591` on either a `node:` builtin import or a `process` access. Declaring `@types/node` takes the ten files from 63 to 2.

The remaining two are real:

```
e2e/support/coverage-fixture.js(28,3): error TS2353: Object literal may only specify known properties, and 'collectCoverage' does not exist in type 'Fixtures<{}, {}, PlaywrightTestArgs & PlaywrightTestOptions, PlaywrightWorkerArgs & PlaywrightWorkerOptions>'.
e2e/support/run-development-tests.mjs(18,22): error TS2339: Property 'E2E_BASE_URL' does not exist on type '{ VITE_COVERAGE: string; }'.
```

The `TS2339` is only visible **with** `@types/node` installed: the absent package was masking it. `{ ...process.env, VITE_COVERAGE: 'true' }` loses `ProcessEnv`'s index signature in the spread, so the `delete playwrightEnv.E2E_BASE_URL` on the next line has nothing to delete as far as the checker is concerned. A `/** @type {NodeJS.ProcessEnv} */` annotation on the declaration restores it.

The `TS2353` is `base.extend()` being unable to infer a new fixture's type from a bare object literal in a `.js` file, where the explicit type argument TypeScript syntax would supply is unavailable. The argument is wrapped in parentheses and given a JSDoc `Fixtures<>` annotation; the body is unchanged apart from one level of indentation.

Neither fix is a `@ts-ignore`, a `@ts-expect-error`, an `as any`, or a JSDoc `{any}`.

### Why the `Fixtures<>` annotation names all four type parameters

Measured, one run per arity:

| Type arguments | Result |
| --- | --- |
| 1 — `{ collectCoverage: void }` | `TS2339: Property 'page' does not exist on type '{ collectCoverage: void; }'` |
| 2 — `+ {}` | same `TS2339` |
| 3 — `+ PlaywrightTestArgs & PlaywrightTestOptions` | 0 errors |
| 4 — `+ PlaywrightWorkerArgs & PlaywrightWorkerOptions` | 0 errors |

So three is the minimum: the third parameter is what supplies `page` to the fixture callback. All four ship anyway, because `Fixtures<T, W, PT, PW>` has four parameters and naming them all states `base`'s contract rather than relying on whatever `PW` defaults to — three passes only because this file happens to use no worker fixture. Happy to cut it to three if you would rather the annotation stay minimal.

## Why one PR rather than several

- **The config change and the two source fixes cannot be split.** Run B above is the widened `include` with `@types/node` and without the fixes: 2 errors, which would leave `main` red on the type-check hook. The fixes only become verifiable once the files are in the program, so they belong with the change that puts them there.
- **The eight `frontend/` files and the two `scripts/` helpers cannot usefully be split.** The two `scripts/*.mjs` cost 0 diagnostics once `@types/node` is declared, and a second PR would edit the same two lines of the same two files for no review benefit.

`"../scripts/**/*"` escapes the project directory, which is safe here because `rootDir` is unset and `noEmit` is true, so there is no emit path to affect. A second `tsconfig.json` at the repository root would be the alternative; I went with the one-line form because it needs no new file, no second `tsc` invocation and no second hook. Say the word if you would prefer the root-project shape and I will cost it properly.

## Scope notes

- `strict` stays `false`. This PR does not touch it.
- `types_or` on the `tsc` hook is unchanged. Its `ts`, `tsx`, `javascript` and `jsx` entries are now actually delivered by `include` rather than merely asserted, and its `json` entry is now a true claim because `tsconfig.json` and `package-lock.json` changes genuinely alter the result.
- `@types/node` is `^24.13.3`, tracking the Node major the image (`node:krypton-alpine`) and `engines.node` already pin. A caret rather than an exact pin so `update-dependencies.sh` can keep it current inside the 24 line.

## Validation

Run in a local development shell at `b46ad3cc0`:

- `./scripts/lint.sh` — clean. All 16 prek hooks pass, `npm audit` reports 0 vulnerabilities, and the production bundle builds.
- `./scripts/test.sh` — backend pytest **PASS**, frontend Playwright E2E **PASS** (5 passed). This matters here: `coverage-fixture.js` is the fixture every spec imports and `run-development-tests.mjs` is the runner `npm run test:e2e` invokes, so both edited files are exercised by the run. Frontend coverage still reports (57.6% lines, 41.5% branches), which is the evidence that the `auto: true` fixture still fires after the annotation wrap.
- Hook selection was checked with a negative control: `prek run tsc --files scripts/coverage-summary.mjs` reports `(no files to check) Skipped` under `^frontend/` and `Passed` under `^(frontend|scripts)/`.

## Documentation

`AGENTS.md`'s testing bullet said to run the TypeScript check for *frontend* changes. The JavaScript helpers under `scripts/` are now covered by the same project, so the bullet is updated to say so. Nothing else in `README.md`, `docs/` or `AGENTS.md` describes the type-check scope, and no user-visible behaviour changes.
