### PR TITLE
chore(prek): retire the two hook settings that restate their upstream manifests

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -48,7 +48,6 @@ rev = "v0.11.0.1"
 
 [[repos.hooks]]
 id = "shellcheck"
-types = ["shell"]
 args = ["-x"]
 
 [[repos]]
@@ -66,7 +65,7 @@ rev = "v2.3.0"
 [[repos.hooks]]
 id = "mypy"
 language_version = ">=3.13"
-args = ["--config-file=pyproject.toml"]
+args = []
 additional_dependencies = [
   "aiohttp",
   "apscheduler",


### PR DESCRIPTION
Two settings in `prek.toml` restate the upstream hook manifest that the pinned `rev` already supplies. Deleting one and emptying the other leaves the configuration stating only what this project actually chose. No code changes, no behaviour changes: `prek run --all-files` reports the same 16/16 hooks passing before and after, and the shellcheck hook receives a byte-identical file list.

**`shellcheck`: delete `types = ["shell"]`.** It is a verbatim restatement. The `shellcheck-py` manifest at the pinned rev `v0.11.0.1` reads:

```yaml
- id: shellcheck
  name: shellcheck
  description: Test shell scripts with shellcheck
  entry: shellcheck
  language: python
  types: [shell]
  require_serial: true
```

`args = ["-x"]` stays: the manifest declares no `args`, and `-x` (`--external-sources`) is off by default in shellcheck itself.

**`mypy`: reduce `args` to `[]` rather than deleting the key.** Setting `args` replaces the manifest's value wholesale, and `mirrors-mypy`'s manifest declares `args: ["--ignore-missing-imports", "--scripts-are-modules"]`. Deleting the key would silently re-enable both, and `--ignore-missing-imports` is a suppression this project has never opted into. But the value `["--config-file=pyproject.toml"]` is inert, because mypy discovers `pyproject.toml` unaided. `args = []` keeps the two manifest flags suppressed while stating nothing mypy already does.

## Verification

The resolved command line was read directly from the `execve` of the hook process under all three configurations, rather than inferred from the config schema:

| `prek.toml` | flags mypy actually receives |
| --- | --- |
| `args = ["--config-file=pyproject.toml"]` (before) | `--config-file=pyproject.toml` |
| key deleted (negative control) | `--ignore-missing-imports --scripts-are-modules` |
| `args = []` (this PR) | none |

The negative control confirms that deleting the key is the unsafe form, and that an explicitly empty `args` replaces the manifest value rather than falling back to it.

That the hook still reads `pyproject.toml` under `args = []` was checked with a positive control rather than by observing a green hook on an already-clean tree: setting `disallow_any_explicit = true` in `[tool.mypy]` turns the hook red with `explicit-any` errors, so the config file is genuinely in force. Config discovery was confirmed against the hook's own pinned interpreter — `mirrors-mypy` at `v2.3.0` is a placeholder package whose `setup.py` reads `install_requires=['mypy==2.3.0']`, and that mypy logs `Config File: .../pyproject.toml` with no `--config-file` given. No `mypy.ini`, `.mypy.ini` or `setup.cfg` is tracked, so nothing earlier in mypy's search order can win.

For shellcheck, the argument vector is unchanged across the deletion — same seven files in the same order, `-x` retained:

```text
shellcheck -x scripts/lint.sh scripts/update-dependencies.sh start.sh \
  scripts/start-backend.sh scripts/test.sh scripts/setup.sh scripts/test-container.sh
```

## Caveat worth recording

Both deletions are sound because both hooks are pinned to an exact rev, so there is no unpinned resolution to reason about. **They stay sound only until a rev is bumped.** `scripts/update-dependencies.sh` runs `prek update`, which will bump them; if either manifest later changes its `types` or its `args`, these two lines are where that change would have been masked.

## Docs and tests

No documentation is made stale. `README.md`, `docs/` and `AGENTS.md` describe hooks only at the level of "`prek.toml`: repository hook configuration" and "some hooks apply safe fixes"; none names a hook setting, mypy's config path, or shellcheck's file selection.

No tests are affected: nothing under `tests/` or `frontend/e2e/` reads `prek.toml`. Both tracked readers were re-run and report no change — `scripts/sync-mypy-hook-dependencies.py` prints "Mypy hook dependencies are current", and `scripts/sync-biome-prek-hook.mjs 2.5.7 prek.toml` prints "Biome prek hook already uses v2.5.7". This PR changes no backend behaviour, so no pytest coverage is added.

`./scripts/lint.sh` and `./scripts/test.sh` both pass.
