### PR TITLE
refactor(app): drop the two type tests no rule can catch

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -237,7 +237,7 @@ async def check_and_notify_count_increments(cfg: dict, new_status: dict, label: 
     """Check for increments in hit & run and unsatisfied counts and send notifications."""
     # Get the previous status
     old_status = cfg.get("last_status", {})
-    if not isinstance(old_status, dict) or not isinstance(new_status, dict):
+    if not isinstance(old_status, dict):
         return
 
     # Get UID for deduplication (same account across different sessions)
@@ -1229,7 +1229,6 @@ async def api_status(label: str = Query(None), force: int = Query(0)) -> dict[st
         and not just_created_session
         and not suppress_next_event
     ):
-        safe_status = status if isinstance(status, dict) else {}
         prev_ip = cfg.get("last_seedbox_ip")
         prev_asn = cfg.get("last_seedbox_asn")
         proxied_ip = cfg.get("proxied_public_ip")
@@ -1270,7 +1269,7 @@ async def api_status(label: str = Query(None), force: int = Query(0)) -> dict[st
             event_ip_compare = f"{prev_ip} -> {attempted_ip}"
             event_asn_compare = f"{prev_asn} -> {attempted_asn}"
         else:
-            event_status_message = build_status_message(safe_status, ip_monitoring_mode)
+            event_status_message = build_status_message(status, ip_monitoring_mode)
             event_ip_compare = f"{prev_ip} -> {curr_ip}"
             event_asn_compare = f"{prev_asn} -> {curr_asn}"
         # Determine event type
@@ -1281,7 +1280,7 @@ async def api_status(label: str = Query(None), force: int = Query(0)) -> dict[st
         else:
             event_type = "scheduled"
         # All variables are defined in this scope, so log event here
-        auto_update_val = get_auto_update_val(safe_status)
+        auto_update_val = get_auto_update_val(status)
         event = {
             "timestamp": now.isoformat(),
             "label": label,

--- a/tests/backend/test_count_increment_notifications.py
+++ b/tests/backend/test_count_increment_notifications.py
@@ -1,0 +1,91 @@
+"""Backend tests for the hit-and-run and unsatisfied count increment notifier."""
+
+from typing import Any
+
+import pytest
+
+from backend import app
+
+
+@pytest.fixture
+def sent_notifications(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Record notifications instead of dispatching them, over an empty dedup cache."""
+    sent: list[dict[str, Any]] = []
+
+    async def fake_notify_event(**kwargs: Any) -> None:
+        """Capture the keyword payload the notifier would have dispatched."""
+        sent.append(kwargs)
+
+    monkeypatch.setattr(app, "notify_event", fake_notify_event)
+    monkeypatch.setattr(app, "notification_dedup_cache", {})
+    return sent
+
+
+def _status(inact_hnr: int, inact_unsat: int) -> dict[str, Any]:
+    """Build a MAM status payload carrying the two counts the notifier compares.
+
+    Args:
+        inact_hnr: Value for the inactive hit-and-run count.
+        inact_unsat: Value for the inactive unsatisfied count.
+
+    Returns:
+        A status mapping shaped like the one ``get_status`` returns.
+
+    """
+    return {
+        "raw": {
+            "uid": 7,
+            "username": "reader",
+            "inactHnr": {"count": inact_hnr},
+            "inactUnsat": {"count": inact_unsat},
+        }
+    }
+
+
+async def test_non_mapping_last_status_returns_without_notifying(
+    sent_notifications: list[dict[str, Any]],
+) -> None:
+    """A persisted non-mapping ``last_status`` stops the comparison before it reads ``raw``."""
+    cfg = {"last_status": "corrupted-by-hand", "mam": {"mam_id": "cookie"}}
+
+    await app.check_and_notify_count_increments(cfg, _status(9, 9), "seedbox")
+
+    assert sent_notifications == []
+
+
+async def test_missing_last_status_defaults_to_an_empty_mapping(
+    sent_notifications: list[dict[str, Any]],
+) -> None:
+    """An absent ``last_status`` passes the guard and compares against zero counts."""
+    cfg: dict[str, Any] = {"mam": {"mam_id": "cookie"}}
+
+    await app.check_and_notify_count_increments(cfg, _status(2, 0), "seedbox")
+
+    assert [event["event_type"] for event in sent_notifications] == ["inactive_hit_and_run"]
+
+
+async def test_both_counts_increasing_notify_once_each(
+    sent_notifications: list[dict[str, Any]],
+) -> None:
+    """Increments in both counts each raise their own notification."""
+    cfg = {"last_status": _status(1, 4), "mam": {"mam_id": "cookie"}}
+
+    await app.check_and_notify_count_increments(cfg, _status(3, 6), "seedbox")
+
+    assert [event["event_type"] for event in sent_notifications] == [
+        "inactive_hit_and_run",
+        "inactive_unsatisfied",
+    ]
+    assert "increased by 2 (from 1 to 3)" in sent_notifications[0]["message"]
+    assert "increased by 2 (from 4 to 6)" in sent_notifications[1]["message"]
+
+
+async def test_unchanged_counts_notify_nothing(
+    sent_notifications: list[dict[str, Any]],
+) -> None:
+    """Equal counts on both sides raise no notification."""
+    cfg = {"last_status": _status(3, 6), "mam": {"mam_id": "cookie"}}
+
+    await app.check_and_notify_count_increments(cfg, _status(3, 6), "seedbox")
+
+    assert sent_notifications == []

--- a/tests/backend/workflows/test_mam_status_workflow.py
+++ b/tests/backend/workflows/test_mam_status_workflow.py
@@ -64,3 +64,62 @@ async def test_forced_status_fetches_mam_account_and_persists_result(
     persisted = (await api_client.get("/api/session/seedbox")).json()
     assert persisted["last_status"]["points"] == 1234
     assert persisted["last_status"]["raw"]["uid"] == 7
+
+
+@pytest.mark.workflow
+async def test_logged_status_event_reports_the_fetched_auto_update_result(
+    api_client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Log the event-log entry from the fetched status rather than from an empty mapping."""
+    monkeypatch.setattr(app, "register_session_job", lambda _label: None)
+    session = {
+        "label": "seedbox",
+        "mam": {
+            "mam_id": "mam-cookie",
+            "session_type": "ip",
+            "ip_monitoring_mode": "static",
+        },
+        "mam_ip": "198.51.100.10",
+        "proxy": {},
+    }
+    assert (await api_client.post("/api/session/save", json=session)).is_success
+
+    async def ipinfo(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        """Return deterministic public IP metadata."""
+        return {"ip": "198.51.100.10", "asn": "AS64500"}
+
+    async def asn_lookup(*_args: Any, **_kwargs: Any) -> tuple[str, str]:
+        """Return deterministic ASN and timezone metadata."""
+        return "AS64500", "UTC"
+
+    async def mam_seen(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        """Return deterministic MAM-observed network metadata."""
+        return {"ASN": 64500, "AS": "AS64500 TEST-NET"}
+
+    async def mam_status(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        """Return a status whose auto-update result the event log must reproduce."""
+        return {
+            "mam_cookie_exists": True,
+            "points": 1234,
+            "auto_update_seedbox": {"success": True, "msg": "Seedbox IP updated"},
+            "raw": {"uid": 7, "username": "reader"},
+        }
+
+    monkeypatch.setattr(app, "get_ipinfo_with_fallback", ipinfo)
+    monkeypatch.setattr(app, "get_asn_and_timezone_from_ip", asn_lookup)
+    monkeypatch.setattr(app, "get_mam_seen_ip_info", mam_seen)
+    monkeypatch.setattr(app, "get_status", mam_status)
+
+    # A newly created session suppresses its first status event, so the assertion
+    # below is about the second check and the log is cleared between the two.
+    assert (await api_client.get("/api/status?label=seedbox&force=1")).status_code == 200
+    assert (await api_client.delete("/api/ui_event_log")).json() == {"success": True}
+    assert (await api_client.get("/api/status?label=seedbox&force=1")).status_code == 200
+
+    events = (await api_client.get("/api/ui_event_log")).json()
+    manual = [event for event in events if event.get("event_type") == "manual"]
+    assert len(manual) == 1
+    assert manual[0]["details"]["auto_update"] == "Seedbox IP updated"
+    assert manual[0]["status_message"] == (
+        "Static IP mode - No monitoring active. Automation running normally."
+    )


### PR DESCRIPTION
Two runtime `isinstance` checks in `backend/app.py` can never take their false branch, and unlike the rest of that family neither is reported by any linter or type-check rule at any setting. They can only be found by reading, so this is a small standalone change rather than part of a suppression sweep.

**`app.py:240`**

```python
old_status = cfg.get("last_status", {})
if not isinstance(old_status, dict) or not isinstance(new_status, dict):
    return
```

`check_and_notify_count_increments` declares `new_status: dict`, so the right operand is always false. The left operand is not: `cfg.get("last_status", {})` comes out of a `dict` and is `Any`, and a hand-edited or truncated session file really can put a non-mapping there. So the right operand is *evaluated* and merely always false, which is a redundant expression rather than an unreachable statement. `warn_unreachable` fires on statements that cannot execute and this one executes on every call, and mypy has no diagnostic at all for an always-false right operand of `or`. Verified by running `mypy --warn-unreachable` and `mypy --enable-error-code redundant-expr` over `backend/` and `tests/`: neither reports this line.

**`app.py:1232`**

```python
safe_status = status if isinstance(status, dict) else {}
```

`status` is initialised from `session_status_cache` at `app.py:1069`, which is `dict[str, Any]`, so it is `Any` and nothing narrows it. But the two blocks above are exact complements: `if not force and status:` returns the cached payload, and `if force or not status:` runs a real check and rebinds `status = mam_status` before the line is reached, with no early return or `try` in between. Every path that reaches this line has `status` bound to `get_status`'s return, declared `-> dict[str, Any]` at `mam_api.py:96`. The `else {}` arm is therefore dead at runtime while remaining invisible to the checker, which is why `redundant-expr` does not report it either. `safe_status` had no other purpose, so it goes with the test and its two readers take `status` directly.

Nothing else in the file changes; the other `isinstance` sites are a different argument and are not touched here.

## Tests

`tests/backend/test_count_increment_notifications.py` is new and covers `check_and_notify_count_increments` directly: a non-mapping `last_status` returns without notifying, an absent one compares against zero, matching counts notify nothing, and increases in both counts raise one notification each. Removing the surviving `isinstance` guard turns the first of these red with `AttributeError: 'str' object has no attribute 'get'`, so it pins the operand that was kept.

`test_logged_status_event_reports_the_fetched_auto_update_result` drives `/api/status?force=1` to the event-log branch and asserts the entry's `details.auto_update` is built from the fetched status. Substituting `{}` for `status` at that call site turns it red with `assert 'N/A' == 'Seedbox IP updated'`, so the assertion distinguishes the two arms of the deleted conditional rather than passing either way.

## Validation

`./scripts/lint.sh` (16/16 hooks) and `./scripts/test.sh` (86 backend pytest, 5 Playwright E2E) both clean. No user-visible behaviour changes and no documentation references either site, so `README.md` and `docs/` are unaffected.
