### PR TITLE
refactor(port_monitor): collapse the twice-copied invalid-IP predicate

### DIFF
--- a/backend/port_monitor.py
+++ b/backend/port_monitor.py
@@ -34,6 +34,12 @@ PORT_MONITOR_STOP_TIMEOUT_SECONDS = 5.0
 PORT_MONITOR_CONFIG_PATH = Path(
     os.environ.get("PORT_MONITOR_CONFIG_PATH") or CONFIG_DIR / "port_monitoring_stacks.yaml"
 )
+_INVALID_IP_MARKERS = ("not found", "OCI runtime exec", "command not found")
+
+
+def _is_invalid_container_ip(ip: str) -> bool:
+    """True if a container IP probe returned no usable address (empty or an error string)."""
+    return not ip or any(marker in ip for marker in _INVALID_IP_MARKERS)
 
 
 class PortMonitorStack:
@@ -278,12 +284,7 @@ class PortMonitorStackManager:
                 # Try curl first
                 exec_result = container.exec_run("curl -s https://ipinfo.io/ip")
                 ip = exec_result.output.decode().strip()
-                if (
-                    not ip
-                    or "not found" in ip
-                    or "OCI runtime exec" in ip
-                    or "command not found" in ip
-                ):
+                if _is_invalid_container_ip(ip):
                     # Try wget as fallback
                     exec_result = container.exec_run("wget -qO- https://ipinfo.io/ip")
                     ip = exec_result.output.decode().strip()
@@ -293,12 +294,7 @@ class PortMonitorStackManager:
                     container_name,
                     ip,
                 )  # Changed to DEBUG
-                if (
-                    not ip
-                    or "not found" in ip
-                    or "OCI runtime exec" in ip
-                    or "command not found" in ip
-                ):
+                if _is_invalid_container_ip(ip):
                     warning_key = f"no_ip_{container_name}"
                     if self._should_log_warning(warning_key, min_interval=60):
                         _logger.warning(

--- a/tests/backend/test_port_monitor.py
+++ b/tests/backend/test_port_monitor.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 import logging
 from pathlib import Path
 import threading
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
@@ -618,3 +618,78 @@ def test_update_stack_restores_values_on_save_failure(monkeypatch: pytest.Monkey
         ["secondary"],
     )
     assert (stack.interval, stack.public_ip) == (60, "1.1.1.1")
+
+
+_UNUSABLE_PROBE_OUTPUTS = [
+    "",
+    "sh: curl: not found",
+    "OCI runtime exec failed",
+    "bash: curl: command not found",
+]
+
+
+def _manager_with_probe_outputs(
+    monkeypatch: pytest.MonkeyPatch, *outputs: str
+) -> tuple[port_monitor.PortMonitorStackManager, Mock, Mock]:
+    """Build a manager whose in-container IP probe replays the given stdout in order.
+
+    Args:
+        monkeypatch: Fixture used to replace the outbound host connection.
+        *outputs: Stdout each successive ``exec_run`` call returns, curl first.
+
+    Returns:
+        The manager holding one stack, the container double recording the probe
+        commands, and the stub standing in for ``socket.create_connection``.
+    """
+    container = Mock()
+    container.exec_run.side_effect = [Mock(output=output.encode()) for output in outputs]
+    client = Mock()
+    client.containers.get.return_value = container
+    connect = Mock(return_value=MagicMock())
+    monkeypatch.setattr(port_monitor.socket, "create_connection", connect)
+    manager = port_monitor.PortMonitorStackManager()
+    manager.stacks = [port_monitor.PortMonitorStack("x", "container", 80, [])]
+    manager._docker_client = client
+    return manager, container, connect
+
+
+def test_check_port_uses_the_curl_address_without_retrying(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A usable curl probe is accepted as it stands, with no wget fallback."""
+    manager, container, connect = _manager_with_probe_outputs(monkeypatch, "203.0.113.7")
+
+    assert manager.check_port("container", 80)
+
+    assert container.exec_run.call_count == 1
+    connect.assert_called_once_with(("203.0.113.7", 80), timeout=3)
+    assert manager.stacks[0].public_ip_detected is True
+
+
+@pytest.mark.parametrize("unusable", _UNUSABLE_PROBE_OUTPUTS)
+def test_check_port_retries_with_wget_when_curl_returns_no_usable_ip(
+    monkeypatch: pytest.MonkeyPatch, unusable: str
+) -> None:
+    """An unusable curl probe falls back to wget and the port check uses its address."""
+    manager, container, connect = _manager_with_probe_outputs(monkeypatch, unusable, "203.0.113.7")
+
+    assert manager.check_port("container", 80)
+
+    commands = [call.args[0] for call in container.exec_run.call_args_list]
+    assert len(commands) == 2
+    assert commands[0].startswith("curl ")
+    assert commands[1].startswith("wget ")
+    connect.assert_called_once_with(("203.0.113.7", 80), timeout=3)
+    assert manager.stacks[0].public_ip_detected is True
+
+
+@pytest.mark.parametrize("unusable", _UNUSABLE_PROBE_OUTPUTS)
+def test_check_port_gives_up_when_both_probes_return_no_usable_ip(
+    monkeypatch: pytest.MonkeyPatch, unusable: str
+) -> None:
+    """Both probes unusable clears public_ip_detected and never dials the host."""
+    manager, container, connect = _manager_with_probe_outputs(monkeypatch, unusable, unusable)
+
+    assert not manager.check_port("container", 80)
+
+    assert container.exec_run.call_count == 2
+    connect.assert_not_called()
+    assert manager.stacks[0].public_ip_detected is False


### PR DESCRIPTION
## Summary

`check_port` contains the same four-clause container-IP validity test **twice, character for character**, twelve lines apart. The first copy (`backend/port_monitor.py:281-286`) decides whether to retry the exec probe with `wget` after `curl` returned something unusable; the second (`:296-301`) decides whether to give up, log a throttled warning and set `public_ip_detected = False`. Adding a marker string to one copy and not the other silently splits "retry" from "fail", and nothing in the file or in the suite enforces that the two agree.

This collapses both onto one module-level marker tuple and one private predicate. Twelve lines become two call sites.

No user-visible behaviour changes. The predicate is lifted verbatim: same four clauses, same marker strings, same short-circuit order, same two decisions.

## Files touched

- `backend/port_monitor.py` — new `_INVALID_IP_MARKERS` and `_is_invalid_container_ip`, both `if` blocks replaced by a call. +8 −12.
- `tests/backend/test_port_monitor.py` — first coverage of the probe path.

No documentation changes. The marker strings are internal to the exec probe, and `check_port`, `public_ip_detected` and the marker strings themselves appear nowhere in `docs/`, `README.md` or `AGENTS.md`. `grep -rni 'oci runtime|command not found'` across those returns nothing; the 13 case-insensitive hits for the substring `not found` are all unrelated indexer and session messages.

## Tests

`check_port` had **zero** coverage before this change. Every reference to it in the suite replaces it with a `Mock` or a `monkeypatch.setattr`, so nothing constructed an `exec_run` result or exercised either copy of the predicate. That is precisely why the two copies could drift apart unnoticed.

Nine new cases, driving the real `check_port` through a docker-client double:

- `test_check_port_uses_the_curl_address_without_retrying` — a usable `curl` result is accepted as it stands, with no `wget` call.
- `test_check_port_retries_with_wget_when_curl_returns_no_usable_ip` — parametrized over `""`, `sh: curl: not found`, `OCI runtime exec failed` and `bash: curl: command not found`; asserts the `wget` fallback fires and its address is the one dialled.
- `test_check_port_gives_up_when_both_probes_return_no_usable_ip` — same four inputs; asserts `public_ip_detected` is cleared, `check_port` returns `False`, and no host connection is attempted.

The two commits are ordered so the equivalence is checkable: the test commit lands **first**, against the duplicated code, where all nine pass. They then pass unchanged after the collapse.

The tests were verified to catch the defect rather than merely pass. With each of the following mutations applied in turn, the named tests fail:

| Mutation | Tests that fail |
| --- | --- |
| Retry site reverted to three clauses, `OCI runtime exec` dropped | `retries_with_wget`, `gives_up` |
| Give-up site reverted to three clauses, `OCI runtime exec` dropped | `gives_up` |
| `OCI runtime exec` removed from the marker tuple | `retries_with_wget`, `gives_up` |
| Predicate hardcoded to `True` | `uses_the_curl_address`, `retries_with_wget` |
| Predicate hardcoded to `False` | `retries_with_wget`, `gives_up` |

One mutation is **not** detectable, and it is worth recording rather than hiding: removing `command not found` from the marker tuple changes nothing, because any string containing `command not found` also contains `not found`. That clause was already inert in the original duplicated form, so this is a pre-existing property faithfully preserved, not something the refactor introduced.

Coverage of `backend/port_monitor.py` moves from 62% to 71%. Within `check_port`, what remains uncovered is the manual `public_ip` override path, the missing-docker-client path, the exception handler and the unreachable-port path, all outside this change.

## Validation

Run in a local dev environment on `main` + this branch:

- `./scripts/lint.sh` — all 16 hooks pass, including mypy, ruff check, ruff format, tsc and biome.
- `./scripts/test.sh` — backend pytest PASS (36 in `test_port_monitor.py`, up from 27), frontend Playwright E2E PASS.

## Deployment and data compatibility

None. No configuration, schema, persisted state or API surface is touched.
