### PR TITLE
chore(biome): enforce the accessibility rule the recommended preset leaves off

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,6 +17,7 @@
   "linter": {
     "rules": {
       "preset": "recommended",
+      "a11y": "error",
       "correctness": {
         "noUnusedVariables": {
           "level": "error",


### PR DESCRIPTION
`biome.json`'s linter runs `preset: "recommended"`, which covers 37 of the 38 rules in Biome's `a11y` group. The 38th, `noNoninteractiveElementInteractions`, is not recommended and so is off entirely — a React + MUI UI gets no warning today when an event handler is attached to an `<li>`, `<ul>`, `<img>` or another content element.

This adds one line enabling the whole group at error severity.

```json
"a11y": "error",
```

The group is clean at this commit, so nothing else changes.

### Why `"error"` and not `"on"`

`noNoninteractiveElementInteractions` has a default severity of `info`, so `"a11y": "on"` would enable it without gating on it. Measured against a probe attaching `onFocus` to a `<ul>`, using the pinned `@biomejs/biome@2.5.7`:

```text
a11y: on      Found 1 info.     exit 0
a11y: error   Found 1 error.    exit 1
```

The other 37 rules already default to `error`, so `"error"` changes no severity that `recommended` was already setting.

### Validation

All measurements taken with the pinned `@biomejs/biome@2.5.7` from `frontend/node_modules`, which is the same version `prek.toml` resolves for the `biome-check` hook, so they describe what CI enforces rather than a newer local binary.

- `prek run biome-check --all-files --dry-run` selects **41 files**. Biome checks 40 of them; `frontend/package-lock.json` is selected but skipped as a protected file ("handled by another tool").
- Over those files the `a11y` group reports **0 violations**, at `on`, `warn`, `info` and `error` alike.
- Negative control, so the added line is demonstrably reachable rather than merely silent: a scratch component with `<ul onFocus={…}>` reports `lint/a11y/useKeyWithClickEvents` only before the change, and both that rule and `lint/a11y/noNoninteractiveElementInteractions` after it. The scratch file was removed before committing.
- `./scripts/lint.sh` — clean, all 16 hooks pass, frontend production build included.
- `./scripts/test.sh` — clean; backend pytest 81 passed, Playwright E2E 5 passed.
- `frontend/node_modules/.bin/biome migrate --write --config-path biome.json` reports "no migration needed" and leaves the file byte-identical, so `./scripts/update-dependencies.sh:113` will not undo the key.

No backend code changes, so no new pytest coverage is required. Nothing here is user-visible and no `README.md`, `docs/` or `AGENTS.md` statement about Biome becomes stale — `AGENTS.md`'s "Run TypeScript and Biome checks for frontend changes" still describes the workflow exactly.
