### PR TITLE
refactor(url_builder): stop round-tripping an int port through str

### DIFF
--- a/backend/url_builder.py
+++ b/backend/url_builder.py
@@ -3,7 +3,7 @@
 from urllib.parse import urlparse
 
 
-def build_service_url(host: str, port: int | str | None, path: str = "") -> str:
+def build_service_url(host: str, port: int, path: str = "") -> str:
     """Build a service URL from host, port, and path.
 
     Tolerates common user input mistakes:
@@ -42,11 +42,7 @@ def build_service_url(host: str, port: int | str | None, path: str = "") -> str:
     if not host:
         raise ValueError("Host is required")
 
-    if port is None or str(port).strip() == "":
-        raise ValueError("Port is required")
-
-    port_int = int(port)
-    scheme = "https" if port_int == 443 else "http"
-    base = f"{scheme}://{host}:{port_int}"
+    scheme = "https" if port == 443 else "http"
+    base = f"{scheme}://{host}:{port}"
 
     return f"{base}{path}"

--- a/tests/backend/test_url_builder.py
+++ b/tests/backend/test_url_builder.py
@@ -1,0 +1,52 @@
+"""Backend tests for service URL construction."""
+
+import pytest
+
+from backend.url_builder import build_service_url
+
+
+@pytest.mark.parametrize(
+    ("host", "port", "path", "expected"),
+    [
+        ("prowlarr.local", 9696, "/api/v1/indexer", "http://prowlarr.local:9696/api/v1/indexer"),
+        ("prowlarr.local", 443, "/api/v1/indexer", "https://prowlarr.local:443/api/v1/indexer"),
+        ("192.168.1.100", 9117, "", "http://192.168.1.100:9117"),
+    ],
+)
+def test_build_service_url_infers_scheme_from_port(
+    host: str,
+    port: int,
+    path: str,
+    expected: str,
+) -> None:
+    """Build the documented URL, inferring https only for port 443."""
+    assert build_service_url(host, port, path) == expected
+
+
+@pytest.mark.parametrize(
+    ("host", "port", "expected"),
+    [
+        ("https://prowlarr.example.com", 9696, "http://prowlarr.example.com:9696"),
+        ("http://prowlarr.example.com", 443, "https://prowlarr.example.com:443"),
+        ("https://prowlarr.example.com/", 443, "https://prowlarr.example.com:443"),
+    ],
+)
+def test_build_service_url_reinfers_scheme_typed_into_the_host_field(
+    host: str,
+    port: int,
+    expected: str,
+) -> None:
+    """Let the port field override a scheme the user typed into the host field."""
+    assert build_service_url(host, port) == expected
+
+
+def test_build_service_url_strips_a_port_embedded_in_the_host_field() -> None:
+    """Prefer the port field over a port the user typed into the host field."""
+    assert build_service_url("prowlarr.local:9696", 8789) == "http://prowlarr.local:8789"
+
+
+@pytest.mark.parametrize("host", ["", "   ", "https://"])
+def test_build_service_url_rejects_a_host_that_resolves_to_nothing(host: str) -> None:
+    """Reject a host field that is empty before or after scheme stripping."""
+    with pytest.raises(ValueError, match="Host is required"):
+        build_service_url(host, 9696)


### PR DESCRIPTION
## Summary

`build_service_url` declares `port: int | str | None`, then converts the value twice on every call: `str(port).strip()` to test for emptiness, and `int(port)` to get it back. Every one of the **22 call sites**, across all five integration modules, passes a parameter its own signature annotates `int`. The union describes an input domain no caller produces, and the two conversions are the price of the false claim.

This narrows the parameter to `int` and deletes the conversions the narrowing makes dead. Net `+2 / -6` in `backend/url_builder.py`, plus a new test file.

## Why it matters

The declared type is the only documentation this helper has about what a port is, and today it says "int, or a string, or nothing", which is wrong on two of the three. A reader has to work out from `int(port)` that the string case is coerced rather than rejected, and from `str(port).strip()` that an all-whitespace string is treated as absent while `0` is not. Narrowing the annotation removes the question instead of answering it.

The conversions also hid a coupling: `scheme = "https" if port_int == 443 else "http"` was correct only *because* of the preceding `int(port)`. Comparing the raw parameter is now sound by the signature rather than by a conversion three lines earlier.

The call-site annotations were checked mechanically rather than read, walking the AST of every `backend/*.py` and reporting the enclosing function's annotation for the second argument:

```
22 call sites in 5 modules
second-argument annotation in the enclosing function: Counter({'int': 22})
```

## What changes

```python
-def build_service_url(host: str, port: int | str | None, path: str = "") -> str:
+def build_service_url(host: str, port: int, path: str = "") -> str:

-    if port is None or str(port).strip() == "":
-        raise ValueError("Port is required")
-
-    port_int = int(port)
-    scheme = "https" if port_int == 443 else "http"
-    base = f"{scheme}://{host}:{port_int}"
+    scheme = "https" if port == 443 else "http"
+    base = f"{scheme}://{host}:{port}"
```

Host handling, scheme stripping, embedded-port stripping and the `Host is required` guards are all untouched.

**For `int` input the output is byte-identical.** Measured exhaustively rather than sampled: the old and new implementations were run side by side over 10 host forms (bare, dotted, `https://`-prefixed, trailing-slash, embedded-port, whitespace-padded, empty) × 4 path forms (empty, and the three shapes the integrations build) × **every port 0-65535**.

```
int ports: compared 2621440 cases, 0 differences
```

The removed `Port is required` branch was unreachable from every caller. All 14 paths that reach an integration function guard the port first: nine use `not all([host, port, api_key])`, which rejects `None` and `""`; the five `*_test` routes use `port is None`. The only input whose behaviour changes in practice is a hand-crafted `{"port": ""}` POST to one of those five endpoints, which moves from `Error: Port is required` to a connection failure against the default port. That is already what `{"port": 0}` does today, since the deleted branch never caught `0` — it built `http://host:0/...` and let the request fail. The UI cannot produce either: all five port fields go through `Number.parseInt(e.target.value, 10) || <default>`, so they emit a number or the default, and have since each field was introduced.

## Tests

`backend/url_builder.py` had no test file; it sat at **7% line coverage** (17 of 19 statements unexercised), reached only by import. It is now at **100%**, statements and branches.

`tests/backend/test_url_builder.py` pins the documented contract: scheme inference from the port, a scheme typed into the host field being stripped and re-inferred, an embedded port being overridden by the port field, and the `Host is required` rejections. **The whole file passes unmodified against `main`**, which is the point — it asserts the behaviour that already exists, so it is a regression gate for this refactor rather than a description of it.

Each assertion was verified to be load-bearing by breaking the code it covers and confirming the expected failure: changing the comparison to `port == "443"` fails the three https cases; deleting the post-strip `if not host` guard fails the `https://` case; deleting the embedded-port strip fails that case. The pre-strip `if not host` guard is the one line no test pins, because it is subsumed by the post-strip guard — noted, not changed, since it is outside this change.

## Not in this change

`backend/automation.py` re-converts already-numeric values 21 times and `backend/api_automation.py` 7 times. That is the same class of defect and is deliberately left alone here; this PR is one function's signature, not the opening move of a sweep.

The five `*_test` routes guarding on `port is None` rather than on the value being a usable port is a separate gap, unchanged by this PR and pre-existing (it is what lets `{"port": 0}` through today).

## Validation

```
./scripts/lint.sh   # 16/16 hooks pass, frontend build clean
./scripts/test.sh   # backend pytest PASS, frontend Playwright E2E PASS
mypy backend/       # Success: no issues found in 27 source files
```

No documentation change: `README.md`, `docs/` and `AGENTS.md` describe the port as a number everywhere they mention it (`"port": 9696`, `port: 9696`), and none of them documents this helper or a string-valued port. No deployment or data-compatibility notes: no persisted format changes, and a session YAML written by any released version holds an integer port.
