### PR TITLE
refactor(ip_lookup): retire the two duplicated provider normalizer arms

### DIFF
--- a/backend/ip_lookup.py
+++ b/backend/ip_lookup.py
@@ -196,11 +196,11 @@ async def get_ipinfo_with_fallback(
                     _logger.debug("%s raw response for IP %s: %s", provider, ip or "self", data)
                     _logger.debug("%s lookup successful for IP %s", provider, ip or "self")
 
-                    # Normalize output for ipinfo_lite and ipinfo_standard
+                    # Normalize output for ipinfo_lite, ipinfo_standard and ipinfo_hardcoded
                     result = None
-                    if provider in ("ipinfo_lite", "ipinfo_standard"):
+                    if provider in ("ipinfo_lite", "ipinfo_standard", "ipinfo_hardcoded"):
                         # ipinfo_lite: ip, asn, as_name, as_domain, country_code, country, continent_code, continent
-                        # ipinfo_standard: ip, org, etc.
+                        # ipinfo_standard and ipinfo_hardcoded (ipinfo.io by hardcoded IP): ip, org, etc.
                         if provider == "ipinfo_lite":
                             asn_num = data.get("asn")
                             as_name = data.get("as_name", "")
@@ -226,27 +226,14 @@ async def get_ipinfo_with_fallback(
                                 "timezone", None
                             ),  # Not present in lite, but included for compatibility
                         }
-                    elif provider == "ipify":
-                        # ipify only returns IP, no ASN data - return None for ASN to indicate unavailable
+                    elif provider in ("ipify", "httpbin_hardcoded"):
+                        # Both return the IP only, no ASN data - return None for ASN to indicate unavailable
                         result = {
                             "ip": data.get("ip"),
                             "asn": None,  # Use None instead of "Unknown ASN" to indicate unavailable data
                             "org": "",
                             "timezone": None,
                         }
-                    elif provider == "ipinfo_hardcoded":
-                        # ipinfo.io via hardcoded IP (same format as ipinfo_standard)
-                        asn_val = str(data.get("org", ""))
-                        org_val = data.get("org", "")
-                        result = {
-                            "ip": data.get("ip"),
-                            "asn": asn_val,
-                            "org": org_val,
-                            "timezone": data.get("timezone", None),
-                        }
-                    elif provider == "httpbin_hardcoded":
-                        # httpbin.org/ip returns just the IP as plain text, handled above
-                        result = {"ip": data.get("ip"), "asn": None, "org": "", "timezone": None}
                     elif provider == "ipapi":
                         # ipapi returns "as" field which may already contain "AS" prefix
                         asn_val = str(data.get("as", ""))

--- a/tests/backend/test_ip_lookup.py
+++ b/tests/backend/test_ip_lookup.py
@@ -1,6 +1,7 @@
 """Backend IP lookup tests for provider-chain response handling."""
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
+import itertools
 from types import TracebackType
 from typing import Any, Self
 
@@ -11,6 +12,9 @@ from backend import ip_lookup
 # ip-api.com, ipinfo.io standard, and ipdata.co: the providers offered for a
 # specific IP once the two token-gated entries are removed from the chain.
 PROVIDERS_FOR_A_SPECIFIC_IP = 3
+# Those three plus ipify.org and the two hardcoded-IP fallbacks, which join the
+# chain only when no IP is supplied.
+PROVIDERS_FOR_A_SELF_LOOKUP = 6
 
 
 class _Noop:
@@ -129,6 +133,28 @@ class _StubSession:
         """Exit the session context."""
 
 
+def _answered_only_at(index: int, payload: Any) -> Callable[[], _StubResponse]:
+    """Build a response factory that answers 503 for every provider but one.
+
+    Args:
+        index: Position in the provider chain whose response carries the payload.
+        payload: Value the provider at that position replays to the caller.
+
+    Returns:
+        Zero-argument callable returning one stub response per request.
+
+    """
+    served = itertools.count()
+
+    def response_factory() -> _StubResponse:
+        """Return the payload at the chosen position and 503 everywhere else."""
+        if next(served) == index:
+            return _StubResponse(payload)
+        return _StubResponse({}, status=503)
+
+    return response_factory
+
+
 @pytest.fixture
 def stub_lookup_chain(monkeypatch: pytest.MonkeyPatch) -> Any:
     """Replace the provider chain's session and cache with test-local doubles."""
@@ -215,3 +241,53 @@ async def test_response_is_released_on_the_success_path(stub_lookup_chain: Any) 
     assert result["asn"] == "AS64500 TEST-NET"
     assert len(session.responses) == 1
     assert session.responses[0].releases == 1
+
+
+async def test_a_self_lookup_offers_every_provider_in_the_chain(stub_lookup_chain: Any) -> None:
+    """Offer all six self-lookup providers before reporting total failure."""
+    session = stub_lookup_chain(lambda: _StubResponse({}, status=503))
+
+    result = await ip_lookup.get_ipinfo_with_fallback()
+
+    assert result == {"ip": None, "asn": None, "org": "", "timezone": None}
+    assert len(session.responses) == PROVIDERS_FOR_A_SELF_LOOKUP
+
+
+@pytest.mark.parametrize(
+    ("index", "payload", "expected"),
+    [
+        pytest.param(
+            3,
+            {"ip": "203.0.113.7"},
+            {"ip": "203.0.113.7", "asn": None, "org": "", "timezone": None},
+            id="ipify",
+        ),
+        pytest.param(
+            4,
+            {"ip": "203.0.113.7", "org": "AS64500 TEST-NET", "timezone": "Etc/UTC"},
+            {
+                "ip": "203.0.113.7",
+                "asn": "AS64500 TEST-NET",
+                "org": "AS64500 TEST-NET",
+                "timezone": "Etc/UTC",
+            },
+            id="ipinfo_hardcoded",
+        ),
+        pytest.param(
+            5,
+            "203.0.113.7\n",
+            {"ip": "203.0.113.7", "asn": None, "org": "", "timezone": None},
+            id="httpbin_hardcoded",
+        ),
+    ],
+)
+async def test_a_self_lookup_normalizes_each_tail_provider(
+    stub_lookup_chain: Any, index: int, payload: Any, expected: dict[str, Any]
+) -> None:
+    """Normalize the payload of each provider only a self lookup reaches."""
+    session = stub_lookup_chain(_answered_only_at(index, payload))
+
+    result = await ip_lookup.get_ipinfo_with_fallback()
+
+    assert result == expected
+    assert len(session.responses) == index + 1


### PR DESCRIPTION
## Summary

`get_ipinfo_with_fallback` normalizes seven provider payloads through one `if`/`elif` chain. Two of its arms are duplicates of another arm, so they are deleted and the two surviving predicates widened to cover their provider names.

No user-visible behaviour changes. The fallback chain's membership and order are untouched.

## The two duplicates

**`ipinfo_hardcoded` duplicated the `ipinfo_standard` else-arm.** Both computed `asn_val = str(data.get("org", ""))` and `org_val = data.get("org", "")` and emitted `"timezone": data.get("timezone", None)`. Its own comment conceded it: `# ipinfo.io via hardcoded IP (same format as ipinfo_standard)`. It is the same ipinfo.io API reached by a hardcoded IP, so the payload shape is necessarily the same. It now joins the `provider in ("ipinfo_lite", "ipinfo_standard", "ipinfo_hardcoded")` head and falls into the same `else` branch `ipinfo_standard` already used.

**`httpbin_hardcoded` duplicated `ipify`.** Both produced `{"ip": data.get("ip"), "asn": None, "org": "", "timezone": None}`, character for character. It now joins the `provider in ("ipify", "httpbin_hardcoded")` arm.

The plain-text handling httpbin needs is not in the normalizer chain at all — it is the `if provider == "httpbin_hardcoded"` branch further up that reads `resp.text()` instead of `resp.json()` and builds `data = {"ip": text.strip()}`. That branch is unchanged, which is why the two arms produce the same dict from the same `data`.

Net −13 lines in one file. The chain goes from six top-level branches to four, over the same seven provider names.

## Does this change the fallback chain?

No. Nothing in the `providers.append` block is touched, so all seven entries still join the chain under the same conditions and in the same order. The change is confined to how an already-received payload is normalized.

`README.md:145-148` enumerates the chain by provider name across four token configurations, each ending `… → ipify → hardcoded`, and `docs/ip-lookup-optimization.md:15,24,32,40` do the same. All eight lines were re-read and none goes stale. The provider capability tables at `README.md:141` and `docs/ip-lookup-optimization.md:72,114` are likewise unaffected.

## Tests

The three arms this PR touches — `ipify`, `ipinfo_hardcoded` and `httpbin_hardcoded` — had **zero coverage**. All four existing cases in `tests/backend/test_ip_lookup.py` call `get_ipinfo_with_fallback("203.0.113.7")` with a specific IP, and the file's own `PROVIDERS_FOR_A_SPECIFIC_IP = 3` records why: those three providers join the chain only behind `if not ip`, so a specific-IP lookup never reaches them.

The first commit adds that coverage and is **green against the unmodified function** (verified by running it against the parent commit's `backend/ip_lookup.py`), so the two commits together are the behaviour-preservation proof rather than an assertion of it:

- `test_a_self_lookup_offers_every_provider_in_the_chain` — every provider answers 503, and the chain offers all six before returning the total-failure dict. This is the membership-and-order gate.
- `test_a_self_lookup_normalizes_each_tail_provider` — parametrized over positions 3, 4 and 5, letting exactly one provider succeed and asserting both the normalized dict and the position at which it answered.

Per negative control, two deliberately wrong merges were run against the new cases before either was trusted:

- swapping the two provider names between the widened predicates fails `[ipinfo_hardcoded]` (`{'asn': ''} != {'asn': None}`) and `[httpbin_hardcoded]`
- deleting the two arms without widening either predicate fails the same two, falling through to the total-failure dict

`[ipify]` passes under both, correctly — neither wrong merge changes the arm it exercises.

## Complexity

`get_ipinfo_with_fallback`'s mccabe score drops **30 → 28**, measured with `ruff check --extend-select C901 --config 'lint.mccabe.max-complexity=0'` at ruff 0.16.2, before and after. Two whole dispatch arms is two decision points.

## Validation

Run in a local Python 3.13.15 / Node 24.19.0 environment against `b46ad3cc0`:

```
./scripts/lint.sh    # 16/16 prek hooks pass, npm audit clean, vite build clean
./scripts/test.sh    # Backend pytest PASS, Frontend Playwright E2E PASS
```

Backend line coverage moves 37.0% to 37.3%, branch coverage 22.1% to 22.5%. Within `backend/ip_lookup.py` alone, lines move 54.5% to 64.7% and branches 48.1% to 62.0%.
