### PR TITLE
chore(docker): drop the vestigial build toolchain and attest the published image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -128,6 +128,9 @@ jobs:
             APP_VERSION=${{ steps.version.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+          # Pinned: unset, the action's provenance mode follows repo visibility.
+          provenance: mode=max
+          sbom: true
           cache-from: |
             type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,13 @@ WORKDIR /app
 COPY pyproject.toml /app/pyproject.toml
 
 # Install system dependencies, create users/groups, and install Python deps
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev \
-    && apk add --no-cache gettext su-exec shadow \
+RUN apk add --no-cache gettext su-exec shadow \
     && (getent group 992 || addgroup -g 992 docker) \
     && addgroup -g 1000 appgroup \
     && adduser -u 1000 -G appgroup -D -s /bin/sh appuser \
     && adduser appuser docker \
     && python -m pip install --no-cache-dir --upgrade "pip>=25.1" \
     && python -m pip install --no-cache-dir --group runtime \
-    && apk del --no-cache .build-deps \
     && rm -rf /root/.cache/pip /tmp/* /var/cache/apk/*
 
 # Set environment variables


### PR DESCRIPTION
Two changes to release-time build configuration. Neither touches application code.

## 1. `Dockerfile`: the `.build-deps` toolchain is vestigial

`gcc musl-dev libffi-dev` are installed and deleted again in the same `RUN` chain, but nothing in the runtime closure needs them. Every distribution the image installs arrives as a wheel.

I enumerated the transitive `runtime` closure and checked PyPI for each distribution at its resolved version: **29 packages on Linux** (31 resolved, 2 excluded by `sys_platform == 'win32'`). Of those, **21 are pure-Python** and **8 ship cp313 musllinux wheels for both `x86_64` and `aarch64`** — `aiohttp`, `pydantic-core`, `yarl`, `pyyaml`, `charset-normalizer`, `frozenlist`, `multidict`, `propcache`. There are **no one-arch-only and no sdist-only** distributions, which is the case that would have made this unsafe.

Verified by building `linux/amd64` with `--no-cache --progress=plain`: exit 0, 29 packages installed, and a word-boundary grep of the full log for `\bgcc\b`, `\bcc1\b`, `building wheel for`, `running build_ext`, `setup.py`, `.tar.gz`, `musl-dev`, `libffi-dev` and `Preparing metadata (pyproject` returned **zero matches**.

Because a grep that never fires proves nothing, I ran a negative control on the same base with no toolchain: `pip install --no-binary :all: --no-deps pyyaml==6.0.3` **failed**, and the same patterns fired on `Downloading pyyaml-6.0.3.tar.gz`, `Building wheel for Cython` and `error: [Errno 2] No such file or directory: 'gcc'`. So the patterns do detect a source build, and `python:3.13-alpine` ships no compiler — `.build-deps` was the only source of one.

On the resulting image `gcc`, `cc1` and `ld` are absent, none of the three packages is installed, and the compiled extensions actually load (`_pydantic_core.cpython-313-x86_64-linux-musl.so`, `yaml.CLoader`), so the wheels are functional rather than merely unpacked. `envsubst`, `su-exec` and `usermod` are all still present, so folding the surviving `apk add` up to start the chain loses nothing.

**This does not shrink the published image.** I measured it rather than assuming: 115,077,708 → 115,076,041 bytes, a difference of 1,667 bytes, which is apk bookkeeping and not the toolchain. The existing `apk del` already ran inside the same layer, so the compiler never landed in a committed layer. What the change actually saves is build work: **18 apk packages and ~202 MiB of transient filesystem**, about 2 s per build on amd64 and more on the emulated arm64 leg.

### The honest limit: arm64 is surveyed, not built

The wheel survey covers `aarch64` completely and cleanly, but **I could not run an arm64 build**. This host has no `linux/arm64` in buildx, `/proc/sys/fs/binfmt_misc` is not mounted, and no QEMU is installed; `docker run --platform linux/arm64 alpine:3 uname -m` dies with `exec format error`. So the arm64 leg rests on the wheel survey plus this workflow's existing `docker/setup-qemu-action` + buildx path, not on a build I ran. I'd rather say that than imply coverage I don't have.

Note that a pull request never builds the release image — `Publish Docker image` fires on `workflow_run` after Tests passes on `main` — so arm64 is first exercised at publish time. `scripts/test-container.sh` builds natively only (no `--platform`), so the container smoke job is not a multi-arch harness.

## 2. `docker-publish.yml`: pin the provenance mode, add an SBOM

A correction to what I first assumed: the input being unset does **not** mean no attestation. I inspected the live artifact, and `ghcr.io/sirjmann92/mousetrap:latest` and `docker.io/sirjmann92/mousetrap:latest` **already carry `mode=max` SLSA provenance** on both platform manifests — the Dockerfile is base64-embedded, `build-arg:APP_VERSION` is present, and `builder-id` is the Actions run URL. So provenance is not missing.

What is missing is the SBOM: `imagetools inspect --format '{{ json .SBOM }}'` returns `{}`.

The reason to set `provenance` explicitly anyway is that **the action's default is not a fixed value**. With the input unset it emits `mode=max` for a public repository and `mode=min,inline-only=true` for a private one (`docker/build-push-action` v7, `src/context.ts` `getAttestArgs`). Making the repository private would therefore silently drop the published attestation manifest. Pinning the mode decouples the supply-chain output from a GitHub repository setting; it is a no-op today, by design.

`mode=max` embeds build arguments and the Dockerfile. The only build argument here is the release version and no `secrets:` are passed to this step, so there is nothing to leak. Keeping `max` also means the published provenance does not change shape.

**Verified locally rather than left until a release.** I built with `--provenance=mode=max --sbom=true` to `--output type=oci` on a `docker-container` builder and unpacked the result: the attestation manifest carries both blobs, `https://spdx.dev/Document` (990,834 bytes) and `https://slsa.dev/provenance/v1`. The negative control — the same build without the flags — produces a plain image manifest with no attestations at all.

The SBOM catalogues 97 distinct packages, including all the runtime distributions and the Alpine ones. It also independently confirms half one: `su-exec`, `gettext` and `shadow` appear, while `gcc`, `musl-dev` and `libffi-dev` do not.

Cost: the syft scan took **0.7 s** for amd64 and adds about **1 MiB per platform** of registry storage. Attestation blobs are not fetched by a normal `docker pull`, so this does not affect users pulling the image. The scanner image is pulled from Docker Hub after this workflow's Docker Hub login step, so the pull is authenticated.

The one thing I could not verify without a real push is the multi-registry push itself, since attestations are only produced on a push. Both registries already accept and serve this exact manifest structure today, so the risk is low, but the acceptance step is a post-merge `docker buildx imagetools inspect` confirming the SBOM landed alongside the provenance.

## Validation

- `./scripts/lint.sh` — clean, all 16 hooks pass, `actionlint` included.
- `./scripts/test.sh --full` — backend pytest **PASS**, frontend Playwright E2E **PASS**, Docker container smoke **PASS**. I used `--full` deliberately: the default mode leaves `RUN_CONTAINER=false`, and the container smoke test is what actually builds this Dockerfile.
- Docs: a case-insensitive grep for `build-deps`, `gcc`, `musl-dev`, `libffi`, `provenance`, `sbom` and `attestation` across `README.md`, `docs/` and `AGENTS.md` finds nothing. No document names the build toolchain or the attestation inputs, and the image's user-facing contract — ports, volumes, environment variables — is unchanged, so the compose examples stay correct.
- Tests: no new test is required for half one, and the reason is `scripts/test-container.sh` — it already builds this image and asserts the container serves, so removing a build-time package is covered by an existing test rather than an absent one. Half two cannot be covered by a test, since attestations are only produced on a real push.
