### PR TITLE
chore: add a coverage floor and record review and landing practice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,40 @@ for backend pytest and `coverage/frontend/` for Playwright E2E.
 - Keep Docker socket operations limited to the port-monitoring feature and avoid
   expanding socket permissions without documentation and user-visible warnings.
 
+## Reviewing Pull Requests
+
+When reviewing a contributor's pull request, verify the claims rather than the
+prose: reproduce a reported defect against the pre-fix code, re-derive any
+measurement the description asserts, and run the checks that match the files
+touched. A description that reads convincingly is not evidence.
+
+Leave a short comment before merging — two to four lines, saying **what was
+independently verified and how**, not that it looks good:
+
+> Verified: reproduced the failure on pre-fix code (both tests fail, pass after).
+> Confirmed `buy_vip`/`buy_wedge` are byte-identical substitutions, so the change
+> is confined to one function. mypy and the backend suite are clean.
+
+This is worth more than an approval stamp on evidence-heavy pull requests: it
+tells the contributor which of their claims were checked, and it records why the
+change was accepted for whoever reads the pull request later. Say so explicitly
+when a claim could not be verified, or when verification went further than the
+author could — for example building an architecture the author had no runner for.
+
+Skip the comment for genuinely trivial changes such as a one-line setting.
+
+## Landing Your Own Changes
+
+Open a pull request for your own changes rather than pushing to `main`, and
+merge it once its checks pass. `gh release create --generate-notes` builds the
+release notes from merged pull requests, so a direct push to `main` ships in the
+release but appears nowhere in its notes — it shows up only in the "Full
+Changelog" commit range. Anything that should be visible to users in a release
+needs a pull request.
+
+Direct pushes remain appropriate for documentation-only changes, which are
+excluded from `Tests` by `paths-ignore` and therefore cut no release at all.
+
 ## Releases and Versioning
 
 Publishing is automatic: a push to `main` runs `Tests`, and a successful run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,11 @@ parallel = false
 
 [tool.coverage.report]
 show_missing = true
+# Ratchet, not a target. Set just below the measured total so an unrelated
+# change cannot quietly reduce coverage; raise it when coverage rises. Several
+# defects found in review sat in modules that had no tests at all, so the floor
+# exists to stop that surface growing rather than to certify the current number.
+fail_under = 40
 
 [tool.pyright]
 venvPath = "."


### PR DESCRIPTION
Three changes, no runtime code touched.

**Coverage floor.** `[tool.coverage.report]` gains `fail_under = 40`, just
below the measured 41.29%. It is a ratchet rather than a target: nothing
previously stopped coverage drifting down, and the defects surfaced in the
recent review sat disproportionately in modules with little or no coverage
(jackett 8%, prowlarr and chaptarr 9%, autobrr 13%, mam_api 23%, app.py
31%), several of which had no test file at all until a fix added one.
Negative-controlled rather than assumed: at `--cov-fail-under=95` the run
exits 1 with "Coverage failure: total of 41 is less than fail-under=95",
so the gate is not inert.

**Reviewing Pull Requests.** Records that a review should verify claims
rather than prose — reproduce the defect against pre-fix code, re-derive
asserted measurements — and should leave a short comment naming what was
independently verified and how. On evidence-heavy pull requests that is
worth more than an approval stamp: it tells the contributor which claims
were checked and records why the change was accepted.

**Landing Your Own Changes.** `gh release create --generate-notes` builds
release notes from merged pull requests, so a direct push to `main` ships
in the release but appears nowhere in its notes. The url_builder port fix
in v2.4.1 is the worked example: it is in the compare range and absent
from the list. Anything user-visible should therefore go through a pull
request; documentation-only changes stay fine to push directly, since
paths-ignore means they cut no release at all.

Validated: `./scripts/lint.sh` clean on all 16 hooks, backend suite passes
with the floor active at 41.29%.