### PR TITLE
fix(config): report a missing session instead of synthesising one

### DIFF
--- a/backend/api_automation.py
+++ b/backend/api_automation.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 
-from backend.config import load_session
+from backend.config import load_session, session_exists
 from backend.event_log import append_ui_event_log
 from backend.mam_api import get_status
 from backend.notifications_backend import notify_event
@@ -65,10 +65,10 @@ async def manual_upload_credit(request: Request) -> dict[str, Any]:
             detail=f"Invalid upload credit amount: {amount}GB. Valid amounts are: {', '.join(map(str, valid_amounts))}GB",
         )
 
-    cfg = load_session(label)
-    if cfg is None:
+    if not session_exists(label):
         _logger.warning("[ManualUpload] Session '%s' not found or not configured.", label)
         return {"success": False, "error": f"Session '{label}' not found."}
+    cfg = load_session(label)
     mam_id = cfg.get("mam", {}).get("mam_id", "")
 
     proxy_cfg = resolve_proxy_from_session_cfg(cfg)
@@ -185,10 +185,10 @@ async def manual_wedge(request: Request) -> dict[str, Any]:
     method = data.get("method", "points")
     if not label:
         raise HTTPException(status_code=400, detail="Session label required.")
-    cfg = load_session(label)
-    if cfg is None:
+    if not session_exists(label):
         _logger.warning("[ManualWedge] Session '%s' not found or not configured.", label)
         return {"success": False, "error": f"Session '{label}' not found."}
+    cfg = load_session(label)
     mam_id = cfg.get("mam", {}).get("mam_id", "")
 
     proxy_cfg = resolve_proxy_from_session_cfg(cfg)
@@ -319,10 +319,10 @@ async def manual_vip(request: Request) -> dict[str, Any]:
             weeks_int = int(weeks)
         except ValueError:
             raise HTTPException(status_code=400, detail=invalid_weeks) from None
-    cfg = load_session(label)
-    if cfg is None:
+    if not session_exists(label):
         _logger.warning("[ManualVIP] Session '%s' not found or not configured.", label)
         return {"success": False, "error": f"Session '{label}' not found."}
+    cfg = load_session(label)
     mam_id = cfg.get("mam", {}).get("mam_id", "")
     proxy_cfg = resolve_proxy_from_session_cfg(cfg)
     now = datetime.now(UTC)

--- a/backend/app.py
+++ b/backend/app.py
@@ -52,6 +52,7 @@ from backend.config import (
     load_config,
     load_session,
     save_session,
+    session_exists,
 )
 from backend.db import close_connection
 from backend.event_log import append_ui_event_log, clear_ui_event_log_for_session
@@ -940,7 +941,7 @@ async def auto_update_seedbox_if_needed(
 
 
 @app.get("/api/status")
-async def api_status(label: str = Query(None), force: int = Query(0)) -> dict[str, Any]:
+async def api_status(label: str | None = Query(None), force: int = Query(0)) -> dict[str, Any]:
     """Return the current status for a session label.
 
     If `force` is truthy, a fresh status check is performed even if a cached
@@ -954,7 +955,7 @@ async def api_status(label: str = Query(None), force: int = Query(0)) -> dict[st
     detected_public_ip_asn = None
     if detected_public_ip:
         asn_full_pub = detected_ipinfo_data.get("asn")
-        match_pub = re.search(r"(AS)?(\d+)", asn_full_pub or "") if asn_full_pub else None
+        match_pub = re.search(r"(AS)?(\d+)", asn_full_pub) if asn_full_pub else None
         detected_public_ip_asn = match_pub.group(2) if match_pub else asn_full_pub
 
     cfg = load_session(label) if label else None
@@ -1075,7 +1076,7 @@ async def api_status(label: str = Query(None), force: int = Query(0)) -> dict[st
     detected_public_ip_as = None
     if detected_public_ip:
         asn_full_pub, _ = await get_asn_and_timezone_from_ip(detected_public_ip)
-        match_pub = re.search(r"(AS)?(\d+)", asn_full_pub or "") if asn_full_pub else None
+        match_pub = re.search(r"(AS)?(\d+)", asn_full_pub) if asn_full_pub else None
         detected_public_ip_asn = match_pub.group(2) if match_pub else asn_full_pub
         detected_public_ip_as = asn_full_pub
     # If session has never been checked (no last_status and not forced), return not configured
@@ -1441,11 +1442,10 @@ def api_load_session(label: str) -> dict[str, Any]:
 
     Raises HTTPException(404) if the session does not exist.
     """
-    cfg = load_session(label)
-    if cfg is None:
+    if not session_exists(label):
         _logger.warning("Session '%s' not found or not configured.", label)
         raise HTTPException(status_code=404, detail=f"Session '{label}' not found.")
-    return cfg
+    return load_session(label)
 
 
 async def _sync_integrations_if_mam_id_changed(
@@ -1820,10 +1820,10 @@ async def api_save_perkautomation(request: Request) -> dict[str, Any]:
         label = data.get("label")
         if not label:
             raise HTTPException(status_code=400, detail="Session label required.")
-        cfg = load_session(label)
-        if cfg is None:
+        if not session_exists(label):
             _logger.warning("Session '%s' not found or not configured.", label)
             return {"success": False, "error": f"Session '{label}' not found."}
+        cfg = load_session(label)
         # Save automation settings to session config
         new_pa = data.get("perk_automation", {})
         old_pa = cfg.get("perk_automation", {})
@@ -1904,10 +1904,10 @@ async def api_update_seedbox(request: Request) -> dict[str, Any]:
         label = data.get("label")
         if not label:
             raise HTTPException(status_code=400, detail="Session label required.")
-        cfg = load_session(label)
-        if cfg is None:
+        if not session_exists(label):
             _logger.warning("Session '%s' not found or not configured.", label)
             raise HTTPException(status_code=404, detail=f"Session '{label}' not found.")
+        cfg = load_session(label)
         mam_id = cfg.get("mam", {}).get("mam_id", "")
         if not mam_id:
             raise HTTPException(status_code=400, detail="MaM ID not configured in session.")
@@ -2202,9 +2202,9 @@ async def api_prowlarr_update(request: Request) -> dict[str, Any]:
         if not label:
             return {"success": False, "message": "Session label required"}
 
-        cfg = load_session(label)
-        if cfg is None:
+        if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
+        cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
         mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")
@@ -2298,9 +2298,9 @@ async def api_chaptarr_update(request: Request) -> dict[str, Any]:
         if not label:
             return {"success": False, "message": "Session label required"}
 
-        cfg = load_session(label)
-        if cfg is None:
+        if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
+        cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
         mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")
@@ -2372,9 +2372,9 @@ async def api_jackett_update(request: Request) -> dict[str, Any]:
         if not label:
             return {"success": False, "message": "Session label required"}
 
-        cfg = load_session(label)
-        if cfg is None:
+        if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
+        cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
         mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")
@@ -2460,9 +2460,9 @@ async def api_audiobookrequest_update(request: Request) -> dict[str, Any]:
         if not label:
             return {"success": False, "message": "Session label required"}
 
-        cfg = load_session(label)
-        if cfg is None:
+        if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
+        cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
         mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")
@@ -2547,9 +2547,9 @@ async def api_autobrr_update(request: Request) -> dict[str, Any]:
         if not label:
             return {"success": False, "message": "Session label required"}
 
-        cfg = load_session(label)
-        if cfg is None:
+        if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
+        cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
         mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")
@@ -2609,9 +2609,9 @@ async def api_indexer_update(request: Request) -> dict[str, Any]:
         if not label:
             return {"success": False, "message": "Session label required"}
 
-        cfg = load_session(label)
-        if cfg is None:
+        if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
+        cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
         mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")

--- a/backend/config.py
+++ b/backend/config.py
@@ -28,6 +28,24 @@ def get_session_path(label: str) -> Path:
     return CONFIG_DIR / f"{SESSION_PREFIX}{label}{SESSION_SUFFIX}"
 
 
+def session_exists(label: str) -> bool:
+    """Return whether a session file exists on disk for ``label``.
+
+    :func:`load_session` synthesises a full default configuration when no file
+    is present, so it can never report a missing session. Callers that need to
+    distinguish "not configured" from "configured with defaults" must ask here
+    before loading.
+
+    Args:
+        label: Session label to look for.
+
+    Returns:
+        ``True`` when a session file exists for the label.
+
+    """
+    return get_session_path(label).is_file()
+
+
 def list_sessions() -> list[str]:
     """Return a list of session labels present in the config directory.
 

--- a/backend/port_monitor.py
+++ b/backend/port_monitor.py
@@ -606,8 +606,11 @@ class PortMonitorStackManager:
             if not self.running:
                 return
             result = self.check_port(stack.primary_container, stack.primary_port)
+            # Re-checked after the blocking call above: another thread can request
+            # shutdown while check_port() runs. mypy narrows self.running to True
+            # from the earlier guard and cannot model that, hence the ignore.
             if not self.running:
-                return
+                return  # type: ignore[unreachable]
             stack.last_checked = time.time()
             stack.last_result = result
             stack.status = "OK" if result else "Failed"
@@ -633,8 +636,11 @@ class PortMonitorStackManager:
                     # Manual IP failure tracking logic
                     manual_ip = stack.public_ip
                     result = self.check_port(stack.primary_container, stack.primary_port)
+                    # Re-checked after the blocking call above: another thread can request
+                    # shutdown while check_port() runs. mypy narrows self.running to True
+                    # from the earlier guard and cannot model that, hence the ignore.
                     if not self.running:
-                        return
+                        return  # type: ignore[unreachable]
                     stack.last_checked = time.time()
                     stack.last_result = result
                     stack.status = "OK" if result else "Failed"
@@ -759,7 +765,12 @@ class PortMonitorStackManager:
             return
         with self._worker_lock:
             if self.thread is not None:
-                if self.thread.is_alive():
+                # Second half of a double-checked lock: the worker lock is released for
+                # load_stacks() above, so a concurrent start() can assign self.thread in
+                # that window. mypy narrows it to None from the first check and cannot
+                # model the re-acquire, so it calls this unreachable. Removing it would
+                # let two callers each spawn a monitor thread.
+                if self.thread.is_alive():  # type: ignore[unreachable]
                     return
                 self.thread = None
             with self._restart_tasks_lock:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
 warn_return_any = false
-warn_unreachable = false
+warn_unreachable = true
 
 [tool.ruff]
 line-length = 100

--- a/tests/backend/integration/test_session_not_found.py
+++ b/tests/backend/integration/test_session_not_found.py
@@ -1,0 +1,71 @@
+"""Backend integration tests for reporting a session that does not exist."""
+
+from httpx import AsyncClient
+import pytest
+
+from backend.config import session_exists
+
+# Endpoints that take a session label in the body and answer 200 with a
+# success flag rather than raising, which is this API's existing convention.
+BODY_LABEL_ENDPOINTS = [
+    "/api/jackett/update",
+    "/api/prowlarr/update",
+    "/api/chaptarr/update",
+    "/api/autobrr/update",
+    "/api/audiobookrequest/update",
+    "/api/indexer/update",
+]
+
+
+def test_session_exists_distinguishes_saved_from_absent(isolated_backend: object) -> None:
+    """`load_session` synthesises defaults, so existence needs its own check."""
+    assert session_exists("never-saved") is False
+
+
+@pytest.mark.integration
+async def test_loading_an_absent_session_is_a_404(api_client: AsyncClient) -> None:
+    """The documented 404 for a missing session is actually raised.
+
+    `load_session` returns a fully populated default config for any label, so
+    this endpoint previously answered 200 with a fabricated session.
+    """
+    response = await api_client.get("/api/session/never-saved")
+
+    assert response.status_code == 404
+    assert "never-saved" in response.json()["detail"]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("endpoint", BODY_LABEL_ENDPOINTS)
+async def test_indexer_updates_report_the_missing_session(
+    api_client: AsyncClient, endpoint: str
+) -> None:
+    """A missing label is reported as such, not as a downstream misconfiguration.
+
+    These previously ran against a synthesised default config and failed later
+    with "MAM ID not configured in session", which points at the wrong thing.
+    """
+    response = await api_client.post(endpoint, json={"label": "never-saved"})
+
+    body = response.json()
+    assert body["success"] is False
+    assert "not found" in body["message"].lower()
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("endpoint", ["/api/automation/vip", "/api/automation/upload_auto"])
+async def test_manual_purchases_report_the_missing_session(
+    api_client: AsyncClient, endpoint: str
+) -> None:
+    """A manual purchase against an absent session is refused before any MAM call.
+
+    `amount` is a valid upload-credit amount so the request reaches the session check rather than
+    being turned away by upload-credit amount validation first.
+    """
+    response = await api_client.post(
+        endpoint, json={"label": "never-saved", "weeks": 4, "amount": 50}
+    )
+
+    body = response.json()
+    assert body["success"] is False
+    assert "not found" in str(body.get("error") or body.get("message", "")).lower()


### PR DESCRIPTION
`load_session` returns a fully populated default config for any label —
`load_yaml_file(path, get_default_config(label), expected_type=dict)`
supplies the default, so it never returns `None`. Every
`if cfg is None:` guard behind it was therefore dead, and MouseTrap has
never reported a session as missing on any of those twelve endpoints.

The failure was not silence, it was a misdiagnosis. Measured against the
previous code:

    GET /api/session/does-not-exist
      before: 200 {"label": "does-not-exist", "mam": {"mam_id": "", ...}}
      after:  404 {"detail": "Session 'does-not-exist' not found."}

    POST /api/jackett/update {"label": "does-not-exist"}
      before: {"success": false, "message": "MAM ID not configured in session"}
      after:  {"success": false, "message": "Session 'does-not-exist' not found"}

Someone who mistyped a label was told to go and check their MAM ID. The
manual upload-credit path went further and attempted a purchase against
the synthesised config before failing on the empty cookie. `api_load_session`
carried a docstring promising the 404 it could not raise.

Adds `config.session_exists`, which asks the filesystem rather than
inferring from a loader that cannot fail, and converts the twelve dead
guards to use it before loading.

Enables `warn_unreachable`, which is what found this. The remaining five
findings it reports are not dead code and are handled as such:

- `api_status(label: str = Query(None))` was annotated `str`, so mypy
  called the `label is None` branch unreachable while it runs at runtime.
  The annotation was wrong; it is now `str | None`.
- Two `or ""` operands inside an `if asn_full_pub` guard are genuinely
  redundant and are dropped.
- Three `port_monitor` checks are correct concurrency guards that mypy
  cannot model, and carry a narrow `type: ignore[unreachable]` with the
  reason. Two re-check `self.running` after a blocking `check_port()`;
  the third is the second half of a double-checked lock whose worker lock
  is released for `load_stacks()`. Deleting any of them would break
  cooperative shutdown or let two callers each spawn a monitor thread.
  `warn_unused_ignores` keeps them honest.

Ten tests cover the behaviour. Verified against the defect rather than
asserted: run with this change's `config.py` but the previous `app.py` and
`api_automation.py`, nine of the ten fail.

Validated: `./scripts/lint.sh` clean on all 16 hooks, backend suite passes,
coverage 42%.