### PR TITLE
chore(ci): report duplicated code without gating on it

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -34,6 +34,75 @@ jobs:
       - name: Audit frontend dependencies
         run: npm --prefix frontend audit --no-fund
 
+  duplication-report:
+    name: Duplication report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 'lts/Krypton'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install npm with script approval support
+        run: npm install --global "npm@>=11.16.0" --ignore-scripts --no-audit --no-fund
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix frontend --strict-allow-scripts --no-fund
+
+      # Reporting only. No threshold is configured, so jscpd exits 0 whatever it
+      # finds; this job cannot fail the build. Adding `--threshold N` turns it
+      # into a gate once the current duplication has been brought down.
+      - name: Report duplicated code
+        run: |
+          set -o pipefail
+          frontend/node_modules/.bin/jscpd backend frontend/src scripts \
+            | tee jscpd-console.txt
+
+      # The console output ends with promotional lines, so the summary is built
+      # from the JSON report rather than by tailing stdout.
+      - name: Publish the summary
+        if: always()
+        run: |
+          python3 - <<'PYEOF' >> "$GITHUB_STEP_SUMMARY"
+          import collections, json, pathlib
+          report = pathlib.Path("coverage/jscpd/jscpd-report.json")
+          print("## Duplicated code\n")
+          print("Reporting only \u2014 this job does not gate.\n")
+          if not report.is_file():
+              print("No report was produced.")
+              raise SystemExit
+          data = json.loads(report.read_text())
+          stats = data.get("statistics", {}).get("total", {})
+          print(
+              f"**{stats.get('clones', 0)} clones**, "
+              f"{stats.get('duplicatedLines', 0)} duplicated lines "
+              f"({float(stats.get('percentage', 0)):.2f}%) across {stats.get('sources', 0)} files.\n"
+          )
+          counts: collections.Counter[str] = collections.Counter()
+          for dup in data.get("duplicates", []):
+              for side in ("firstFile", "secondFile"):
+                  counts[dup[side]["name"]] += 1
+          if counts:
+              print("| File | Clones |")
+              print("| --- | ---: |")
+              for name, n in counts.most_common(12):
+                  print(f"| `{name}` | {n} |")
+          PYEOF
+
+      - name: Upload the duplication report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: duplication-report
+          path: coverage/jscpd/
+          if-no-files-found: ignore
+          retention-days: 14
+
   linters:
     name: Run Linters
     runs-on: ubuntu-latest

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,8 @@
+{
+  "minTokens": 30,
+  "reporters": ["console", "json"],
+  "output": "coverage/jscpd",
+  "absolute": false,
+  "gitignore": true,
+  "ignore": ["**/node_modules/**", "**/build/**", "**/coverage/**", "**/*.json", "**/*.lock"]
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "istanbul-lib-instrument": "^6.0.3",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
+        "jscpd": "^5.1.2",
         "typescript": "^7.0.2",
         "vite": "^7.3.6",
         "vite-plugin-istanbul": "^8.0.0",
@@ -3448,6 +3449,156 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jscpd": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-5.1.2.tgz",
+      "integrity": "sha512-7innyzaMstgJcluIwLxUESsP7znUFtRxiENhcUzv34aDrjzH3mJOF7m/5ecNyQGST8BBlmz8alpTuId0c6OdkQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jscpd": "run-jscpd.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://opencollective.com/jscpd"
+      },
+      "optionalDependencies": {
+        "jscpd-darwin-arm64": "5.1.2",
+        "jscpd-darwin-x64": "5.1.2",
+        "jscpd-linux-arm64-gnu": "5.1.2",
+        "jscpd-linux-arm64-musl": "5.1.2",
+        "jscpd-linux-x64-gnu": "5.1.2",
+        "jscpd-linux-x64-musl": "5.1.2",
+        "jscpd-windows-arm64-msvc": "5.1.2",
+        "jscpd-windows-x64-msvc": "5.1.2"
+      }
+    },
+    "node_modules/jscpd-darwin-arm64": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/jscpd-darwin-arm64/-/jscpd-darwin-arm64-5.1.2.tgz",
+      "integrity": "sha512-6fYVCBHgE154jVVYcRA+9K17q5AXe0/V9wfPf3hBrDQMxqOiI+99ii2CfMT6OkcEtJULqpi+uJENCsjtYn+nmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/jscpd-darwin-x64": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/jscpd-darwin-x64/-/jscpd-darwin-x64-5.1.2.tgz",
+      "integrity": "sha512-udNKAqu7ty6NcHvSwaZ7qCktyN+JwET0Z81e6/s1WmRtHkdd6Hnv0Gix04gRN3aVkfqZzI6YKle0YnYPJe4hOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/jscpd-linux-arm64-gnu": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/jscpd-linux-arm64-gnu/-/jscpd-linux-arm64-gnu-5.1.2.tgz",
+      "integrity": "sha512-FYX3IZPXwEooiDn7fQzHEytRbbsSBNqqHUEzxu32EKBXNyQ1Fx1/8hms26X1RFUJ80zpcKkRQCz1J3hPYsYhFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/jscpd-linux-arm64-musl": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/jscpd-linux-arm64-musl/-/jscpd-linux-arm64-musl-5.1.2.tgz",
+      "integrity": "sha512-SuoKN9xv4pIopLS2yPx3E+ysnmZPNAKdxxAYTwvd6ixrEcO36xIKUma+DGKUw1PLXq1HO6A9M3FlqmnrTCnzYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/jscpd-linux-x64-gnu": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/jscpd-linux-x64-gnu/-/jscpd-linux-x64-gnu-5.1.2.tgz",
+      "integrity": "sha512-1B+rqrw7Jt7/5Sye7ssedRnN8I1qatjUq9tFRcUQvlteR1OgW4lZuGV+DTYOgNaPNzeJN21aLzBGBa9OsxRWMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/jscpd-linux-x64-musl": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/jscpd-linux-x64-musl/-/jscpd-linux-x64-musl-5.1.2.tgz",
+      "integrity": "sha512-46Astr0LnVh/prpqq5/Vehtx18MCvcs0KL8vi49kAIksOe6QdlQ/hdBKH8V61pAAmAgCr64hU9p0dv6DDKHJdg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/jscpd-windows-arm64-msvc": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/jscpd-windows-arm64-msvc/-/jscpd-windows-arm64-msvc-5.1.2.tgz",
+      "integrity": "sha512-19gpnY+Mid71EGGytBcFwsif/Y1+Vfu2Qp0IJ+L3WFD32Zui9O4vvASwvxocgA7z77kiZNh9zF5sZY9+oQB62A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/jscpd-windows-x64-msvc": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/jscpd-windows-x64-msvc/-/jscpd-windows-x64-msvc-5.1.2.tgz",
+      "integrity": "sha512-RZlAnXP7Jmx39LBC66IIpFIGl/Bg4FcSkz4Jr6ThrDm5D1NvM201MDG70Z1i+N3wRrfI8UcDkWp5rsHzGHViSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/jsesc": {
       "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     "istanbul-lib-instrument": "^6.0.3",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-reports": "^3.2.0",
+    "jscpd": "^5.1.2",
     "typescript": "^7.0.2",
     "vite": "^7.3.6",
     "vite-plugin-istanbul": "^8.0.0",


### PR DESCRIPTION
Adds a `Duplication report` job running jscpd over `backend`,
`frontend/src` and `scripts`. It is reporting only: no threshold is
configured, so jscpd exits 0 whatever it finds and the job cannot fail the
build. Confirmed both directions — exit 0 as configured, exit 1 with
`--threshold 5` — so turning it into a gate later is one flag.

**Why not a gate now.** The current tree has 218 clones over 2112 lines,
11.75% of the scanned sources. A gate would fail on the first run.

**Why jscpd rather than pylint.** Measured against a tree that still
contained the duplications fixed in #104 and #108, rather than assumed:

- pylint's `R0801` reports only cross-file similarity, so it found neither.
  It did surface 23 cross-file findings, including an 88-line near-identical
  block shared by `chaptarr_integration` and `prowlarr_integration`.
- jscpd detects intra-file clones and found #108's duplicated normalizer
  arms at `ip_lookup.py:219-227` / `239-246`.

Neither tool found #104's invalid-IP predicate; at six lines it stays under
jscpd's window even at `--min-tokens 20`. Small intra-function duplication
of that shape remains a reading problem, not a tooling one, and this job is
not claimed to catch it.

`--min-tokens 30` is chosen because it detects the #108 shape.

The summary is built from the JSON report rather than by tailing stdout,
because jscpd's console output ends with promotional lines that would
otherwise fill the step summary. It reports the totals and the twelve
files carrying the most clones; today that is `automation.py` (62),
`app.py` (59), `IndexerIntegrations.jsx` (45) and `NotificationsCard.jsx`
(37).

**Dependency.** jscpd 5.1.2 has no runtime dependencies and no install
scripts; the eight further lockfile entries are its per-platform binaries,
declared optional, so only one installs on a given machine. All nine were
checked against the registry: integrity hashes match, all MIT, none run
install scripts. `npm audit` reports 0 vulnerabilities.

Validated: `./scripts/lint.sh` clean on all 16 hooks, actionlint clean.