### PR TITLE
refactor(servarr): share one client between Prowlarr and Chaptarr

### DIFF
--- a/backend/chaptarr_integration.py
+++ b/backend/chaptarr_integration.py
@@ -1,299 +1,58 @@
-"""Chaptarr integration for updating MAM indexer configuration.
+"""Chaptarr integration for syncing the MAM ID to its MyAnonaMouse indexer.
 
-This module provides functionality to:
-- Test Chaptarr API connectivity
-- Auto-detect MyAnonaMouse indexer ID
-- Update MAM ID in Chaptarr when session changes
+The API calls live in :mod:`backend.servarr_client`, which Prowlarr shares. This
+module supplies Chaptarr's service description and keeps the public functions
+the rest of the app imports.
 
-Key differences from Prowlarr:
-- Default port: 8789 (vs 9696)
-- Implementation name: "MyAnonaMouse" (vs "MyAnonamouse")
-- Field name: "MamId" (vs "mamId")
+Chaptarr differs from Prowlarr in three ways, all captured in `CHAPTARR` below:
+it names the implementation in `implementation` and matches case-insensitively,
+it spells the indexer "MyAnonaMouse", and its update PUT needs `forceSave=true`.
+The MAM ID field is `mamId` on both, lowercase.
 """
 
-import json
-import logging
 from typing import Any
 
-import aiohttp
+from backend.servarr_client import (
+    ServarrService,
+    find_indexer_id,
+    get_indexer_config as _get_indexer_config,
+    sync_mam_id,
+    test_connection,
+    update_mam_id,
+)
 
-from backend.url_builder import build_service_url
-
-_logger = logging.getLogger(__name__)
-_TIMEOUT = aiohttp.ClientTimeout(total=10)
+CHAPTARR = ServarrService(
+    name="Chaptarr",
+    config_key="chaptarr",
+    indexer_match_field="implementation",
+    indexer_label="MyAnonaMouse",
+    match_case_insensitive=True,
+    force_save=True,
+)
 
 
 async def test_chaptarr_connection(host: str, port: int, api_key: str) -> dict[str, Any]:
     """Test connection to Chaptarr and return indexer count."""
-    url = build_service_url(host, port, "/api/v1/indexer")
-    headers = {"X-Api-Key": api_key}
-
-    try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.get(url, headers=headers, timeout=_TIMEOUT) as response,
-        ):
-            if response.status == 200:
-                indexers = await response.json()
-                return {
-                    "success": True,
-                    "message": f"Connected successfully. Found {len(indexers)} indexer(s).",
-                    "indexer_count": len(indexers),
-                }
-            if response.status == 401:
-                return {"success": False, "message": "Authentication failed. Check API key."}
-
-            return {"success": False, "message": f"Connection failed: HTTP {response.status}"}
-    except TimeoutError:
-        return {"success": False, "message": "Connection timeout"}
-    except Exception as e:
-        _logger.error("Chaptarr connection test failed: %s", e)
-        return {"success": False, "message": str(e)}
+    return await test_connection(CHAPTARR, host, port, api_key)
 
 
 async def find_mam_indexer_id(host: str, port: int, api_key: str) -> dict[str, Any]:
-    """Find the MyAnonaMouse indexer ID in Chaptarr.
-
-    Fetches all indexers and searches for one with implementation="MyAnonaMouse".
-    Note: Uses case-insensitive matching as Chaptarr dev confirmed it's case-insensitive.
-
-    Args:
-        host: Chaptarr host
-        port: Chaptarr port
-        api_key: Chaptarr API key
-
-    Returns:
-        dict with keys:
-            - success: bool
-            - indexer_id: int (if found)
-            - message: str
-    """
-    url = build_service_url(host, port, "/api/v1/indexer")
-    headers = {"X-Api-Key": api_key}
-
-    try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.get(url, headers=headers, timeout=_TIMEOUT) as response,
-        ):
-            if response.status != 200:
-                return {
-                    "success": False,
-                    "message": f"Failed to fetch indexers: HTTP {response.status}",
-                }
-
-            indexers = await response.json()
-            for indexer in indexers:
-                # Chaptarr uses "MyAnonaMouse" but support case-insensitive matching
-                impl_name = indexer.get("implementation", "")
-                if impl_name.lower() == "myanonamouse":
-                    indexer_id = indexer.get("id")
-                    _logger.info(
-                        "Found MAM indexer in Chaptarr: id=%s, name=%s, implementation=%s",
-                        indexer_id,
-                        indexer.get("name"),
-                        impl_name,
-                    )
-                    return {
-                        "success": True,
-                        "indexer_id": indexer_id,
-                        "message": f"Found MyAnonaMouse indexer (ID: {indexer_id})",
-                    }
-
-            return {
-                "success": False,
-                "message": "MyAnonaMouse indexer not found in Chaptarr. Please add it first.",
-            }
-
-    except Exception as e:
-        _logger.exception("Failed to find MAM indexer")
-        return {"success": False, "message": f"Error: {e!s}"}
+    """Find the MyAnonaMouse indexer ID in Chaptarr, matching case-insensitively."""
+    return await find_indexer_id(CHAPTARR, host, port, api_key)
 
 
 async def get_indexer_config(host: str, port: int, api_key: str, indexer_id: int) -> dict[str, Any]:
-    """Fetch the full indexer configuration from Chaptarr.
-
-    Args:
-        host: Chaptarr host
-        port: Chaptarr port
-        api_key: Chaptarr API key
-        indexer_id: Chaptarr indexer ID
-
-    Returns:
-        dict with keys:
-            - success: bool
-            - config: dict (if successful)
-            - message: str
-    """
-    url = build_service_url(host, port, f"/api/v1/indexer/{indexer_id}")
-    headers = {"X-Api-Key": api_key}
-
-    try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.get(url, headers=headers, timeout=_TIMEOUT) as response,
-        ):
-            if response.status == 200:
-                config = await response.json()
-                return {"success": True, "config": config, "message": "Success"}
-            if response.status == 404:
-                return {
-                    "success": False,
-                    "message": f"Indexer ID {indexer_id} not found.",
-                }
-            return {
-                "success": False,
-                "message": f"HTTP {response.status}: {response.reason}",
-            }
-    except Exception as e:
-        _logger.exception("Failed to fetch indexer config")
-        return {"success": False, "message": f"Error: {e!s}"}
+    """Fetch the full indexer configuration from Chaptarr."""
+    return await _get_indexer_config(CHAPTARR, host, port, api_key, indexer_id)
 
 
 async def update_mam_id_in_chaptarr(
     host: str, port: int, api_key: str, indexer_id: int, new_mam_id: str
 ) -> dict[str, Any]:
-    """Update the MAM ID field in Chaptarr indexer configuration.
-
-    This performs the pull-modify-push workflow:
-    1. GET current indexer config
-    2. Find and update the "MamId" field
-    3. PUT updated config back to Chaptarr with forceSave=true
-
-    Args:
-        host: Chaptarr host
-        port: Chaptarr port
-        api_key: Chaptarr API key
-        indexer_id: Chaptarr indexer ID
-        new_mam_id: New MAM ID to set
-
-    Returns:
-        dict with keys:
-            - success: bool
-            - message: str
-            - old_mam_id: str (if successful)
-    """
-    # Step 1: Get current config
-    get_result = await get_indexer_config(host, port, api_key, indexer_id)
-    if not get_result["success"]:
-        return get_result
-
-    config = get_result["config"]
-
-    # Step 2: Find and update mamId field (lowercase m)
-    old_mam_id = None
-    mam_id_found = False
-
-    fields = config.get("fields", [])
-    for field in fields:
-        # Chaptarr uses "mamId" (lowercase m)
-        if field.get("name") == "mamId":
-            old_mam_id = field.get("value", "")
-            field["value"] = new_mam_id
-            mam_id_found = True
-            _logger.info("Updating MAM ID in Chaptarr: %s -> %s", old_mam_id, new_mam_id)
-            break
-
-    if not mam_id_found:
-        return {
-            "success": False,
-            "message": "MAM ID field not found in indexer configuration.",
-        }
-
-    # Step 3: PUT updated config with forceSave=true
-    url = build_service_url(host, port, f"/api/v1/indexer/{indexer_id}?forceSave=true")
-    headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
-
-    try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.put(url, headers=headers, json=config, timeout=_TIMEOUT) as response,
-        ):
-            if response.status in (200, 202):
-                _logger.info(
-                    "Successfully updated MAM ID in Chaptarr (indexer %s)",
-                    indexer_id,
-                )
-                return {
-                    "success": True,
-                    "message": f"MAM ID updated successfully in Chaptarr (indexer {indexer_id})",
-                    "old_mam_id": old_mam_id,
-                }
-
-            # Try to parse error response as JSON for better error messages
-            error_text = await response.text()
-            try:
-                error_data = json.loads(error_text)
-            except json.JSONDecodeError:
-                return {
-                    "success": False,
-                    "message": f"Failed to update: HTTP {response.status} - {error_text}",
-                }
-            else:
-                return {
-                    "success": False,
-                    "message": f"Failed to update: HTTP {response.status}",
-                    "detail": error_data,  # Pass the full error structure to frontend
-                }
-    except Exception as e:
-        _logger.exception("Failed to update MAM ID in Chaptarr")
-        return {"success": False, "message": f"Error: {e!s}"}
+    """Update the MAM ID on a Chaptarr indexer, forcing a save."""
+    return await update_mam_id(CHAPTARR, host, port, api_key, indexer_id, new_mam_id)
 
 
 async def sync_mam_id_to_chaptarr(session_cfg: dict[str, Any], mam_id: str) -> dict[str, Any]:
-    """High-level function to sync MAM ID to Chaptarr with auto-detection.
-
-    This is the main entry point for updating Chaptarr. It:
-    1. Validates Chaptarr config exists in session
-    2. Auto-detects MAM indexer ID (every time, as requested)
-    3. Updates the MAM ID
-
-    Args:
-        session_cfg: Session configuration dict with chaptarr settings
-        mam_id: New MAM ID to sync
-
-    Returns:
-        dict with success, message, and optional details
-    """
-    chaptarr_cfg = session_cfg.get("chaptarr", {})
-
-    _logger.info(
-        "[Chaptarr] sync_mam_id_to_chaptarr called for session. chaptarr_cfg keys: %s, enabled: %s",
-        list(chaptarr_cfg.keys()),
-        chaptarr_cfg.get("enabled"),
-    )
-
-    # Validate required config
-    if not chaptarr_cfg.get("enabled", False):
-        return {
-            "success": False,
-            "message": "Chaptarr integration is not enabled for this session. Please enable Chaptarr and save your session.",
-        }
-
-    host = chaptarr_cfg.get("host", "").strip()
-    port = chaptarr_cfg.get("port")
-    api_key = chaptarr_cfg.get("api_key", "").strip()
-
-    _logger.info(
-        "[Chaptarr] Config details: host=%s, port=%s, api_key=%s",
-        host,
-        port,
-        "***" if api_key else "(empty)",
-    )
-
-    if not all([host, port, api_key]):
-        return {
-            "success": False,
-            "message": "Chaptarr configuration incomplete. Please configure host, port, and API key, then save your session before updating.",
-        }
-
-    # Auto-detect MAM indexer ID
-    _logger.info("Auto-detecting MAM indexer ID in Chaptarr...")
-    find_result = await find_mam_indexer_id(host, port, api_key)
-    if not find_result["success"]:
-        return find_result
-
-    indexer_id = find_result["indexer_id"]
-
-    # Update MAM ID
-    return await update_mam_id_in_chaptarr(host, port, api_key, indexer_id, mam_id)
+    """Sync the MAM ID to Chaptarr, auto-detecting the indexer each time."""
+    return await sync_mam_id(CHAPTARR, session_cfg, mam_id)

--- a/backend/prowlarr_integration.py
+++ b/backend/prowlarr_integration.py
@@ -1,276 +1,55 @@
-"""Prowlarr integration for updating MAM indexer configuration.
+"""Prowlarr integration for syncing the MAM ID to its MyAnonamouse indexer.
 
-This module provides functionality to:
-- Test Prowlarr API connectivity
-- Auto-detect MyAnonamouse indexer ID
-- Update MAM ID in Prowlarr when session changes
+The API calls live in :mod:`backend.servarr_client`, which Chaptarr shares. This
+module supplies Prowlarr's service description and keeps the public functions
+the rest of the app imports.
 """
 
-import json
-import logging
 from typing import Any
 
-import aiohttp
+from backend.servarr_client import (
+    ServarrService,
+    find_indexer_id,
+    get_indexer_config as _get_indexer_config,
+    sync_mam_id,
+    test_connection,
+    update_mam_id,
+)
 
-from backend.url_builder import build_service_url
-
-_logger = logging.getLogger(__name__)
-_TIMEOUT = aiohttp.ClientTimeout(total=10)
+# Prowlarr names the implementation in `definitionName` and matches it exactly,
+# and does not need forceSave on the update.
+PROWLARR = ServarrService(
+    name="Prowlarr",
+    config_key="prowlarr",
+    indexer_match_field="definitionName",
+    indexer_label="MyAnonamouse",
+    match_case_insensitive=False,
+    force_save=False,
+)
 
 
 async def test_prowlarr_connection(host: str, port: int, api_key: str) -> dict[str, Any]:
     """Test connection to Prowlarr and return indexer count."""
-    url = build_service_url(host, port, "/api/v1/indexer")
-    headers = {"X-Api-Key": api_key}
-
-    try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.get(url, headers=headers, timeout=_TIMEOUT) as response,
-        ):
-            if response.status == 200:
-                indexers = await response.json()
-                return {
-                    "success": True,
-                    "message": f"Connected successfully. Found {len(indexers)} indexer(s).",
-                    "indexer_count": len(indexers),
-                }
-            if response.status == 401:
-                return {"success": False, "message": "Authentication failed. Check API key."}
-
-            return {"success": False, "message": f"Connection failed: HTTP {response.status}"}
-    except TimeoutError:
-        return {"success": False, "message": "Connection timeout"}
-    except Exception as e:
-        _logger.error("Prowlarr connection test failed: %s", e)
-        return {"success": False, "message": str(e)}
+    return await test_connection(PROWLARR, host, port, api_key)
 
 
 async def find_mam_indexer_id(host: str, port: int, api_key: str) -> dict[str, Any]:
-    """Find the MyAnonamouse indexer ID in Prowlarr.
-
-    Fetches all indexers and searches for one with definitionName="MyAnonamouse".
-
-    Args:
-        host: Prowlarr host
-        port: Prowlarr port
-        api_key: Prowlarr API key
-
-    Returns:
-        dict with keys:
-            - success: bool
-            - indexer_id: int (if found)
-            - message: str
-    """
-    url = build_service_url(host, port, "/api/v1/indexer")
-    headers = {"X-Api-Key": api_key}
-
-    try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.get(url, headers=headers, timeout=_TIMEOUT) as response,
-        ):
-            if response.status != 200:
-                return {
-                    "success": False,
-                    "message": f"Failed to fetch indexers: HTTP {response.status}",
-                }
-
-            indexers = await response.json()
-            for indexer in indexers:
-                if indexer.get("definitionName") == "MyAnonamouse":
-                    indexer_id = indexer.get("id")
-                    _logger.info(
-                        "Found MAM indexer in Prowlarr: id=%s, name=%s",
-                        indexer_id,
-                        indexer.get("name"),
-                    )
-                    return {
-                        "success": True,
-                        "indexer_id": indexer_id,
-                        "message": f"Found MyAnonamouse indexer (ID: {indexer_id})",
-                    }
-
-            return {
-                "success": False,
-                "message": "MyAnonamouse indexer not found in Prowlarr. Please add it first.",
-            }
-
-    except Exception as e:
-        _logger.exception("Failed to find MAM indexer")
-        return {"success": False, "message": f"Error: {e!s}"}
+    """Find the MyAnonamouse indexer ID in Prowlarr."""
+    return await find_indexer_id(PROWLARR, host, port, api_key)
 
 
 async def get_indexer_config(host: str, port: int, api_key: str, indexer_id: int) -> dict[str, Any]:
-    """Fetch the full indexer configuration from Prowlarr.
-
-    Args:
-        host: Prowlarr host
-        port: Prowlarr port
-        api_key: Prowlarr API key
-        indexer_id: Prowlarr indexer ID
-
-    Returns:
-        dict with keys:
-            - success: bool
-            - config: dict (if successful)
-            - message: str
-    """
-    url = build_service_url(host, port, f"/api/v1/indexer/{indexer_id}")
-    headers = {"X-Api-Key": api_key}
-
-    try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.get(url, headers=headers, timeout=_TIMEOUT) as response,
-        ):
-            if response.status == 200:
-                config = await response.json()
-                return {"success": True, "config": config, "message": "Success"}
-            if response.status == 404:
-                return {
-                    "success": False,
-                    "message": f"Indexer ID {indexer_id} not found.",
-                }
-            return {
-                "success": False,
-                "message": f"HTTP {response.status}: {response.reason}",
-            }
-    except Exception as e:
-        _logger.exception("Failed to fetch indexer config")
-        return {"success": False, "message": f"Error: {e!s}"}
+    """Fetch the full indexer configuration from Prowlarr."""
+    return await _get_indexer_config(PROWLARR, host, port, api_key, indexer_id)
 
 
 async def update_mam_id_in_prowlarr(
     host: str, port: int, api_key: str, indexer_id: int, new_mam_id: str
 ) -> dict[str, Any]:
-    """Update the MAM ID field in Prowlarr indexer configuration.
-
-    This performs the pull-modify-push workflow:
-    1. GET current indexer config
-    2. Find and update the "mamId" field
-    3. PUT updated config back to Prowlarr
-
-    Args:
-        host: Prowlarr host
-        port: Prowlarr port
-        api_key: Prowlarr API key
-        indexer_id: Prowlarr indexer ID
-        new_mam_id: New MAM ID to set
-
-    Returns:
-        dict with keys:
-            - success: bool
-            - message: str
-            - old_mam_id: str (if successful)
-    """
-    # Step 1: Get current config
-    get_result = await get_indexer_config(host, port, api_key, indexer_id)
-    if not get_result["success"]:
-        return get_result
-
-    config = get_result["config"]
-
-    # Step 2: Find and update mamId field
-    old_mam_id = None
-    mam_id_found = False
-
-    fields = config.get("fields", [])
-    for field in fields:
-        if field.get("name") == "mamId":
-            old_mam_id = field.get("value", "")
-            field["value"] = new_mam_id
-            mam_id_found = True
-            _logger.info("Updating MAM ID in Prowlarr: %s -> %s", old_mam_id, new_mam_id)
-            break
-
-    if not mam_id_found:
-        return {
-            "success": False,
-            "message": "MAM ID field not found in indexer configuration.",
-        }
-
-    # Step 3: PUT updated config
-    url = build_service_url(host, port, f"/api/v1/indexer/{indexer_id}")
-    headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
-
-    try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.put(url, headers=headers, json=config, timeout=_TIMEOUT) as response,
-        ):
-            if response.status in (200, 202):
-                _logger.info(
-                    "Successfully updated MAM ID in Prowlarr (indexer %s)",
-                    indexer_id,
-                )
-                return {
-                    "success": True,
-                    "message": f"MAM ID updated successfully in Prowlarr (indexer {indexer_id})",
-                    "old_mam_id": old_mam_id,
-                }
-
-            # Try to parse error response as JSON for better error messages
-            error_text = await response.text()
-            try:
-                error_data = json.loads(error_text)
-            except json.JSONDecodeError:
-                return {
-                    "success": False,
-                    "message": f"Failed to update: HTTP {response.status} - {error_text}",
-                }
-            else:
-                return {
-                    "success": False,
-                    "message": f"Failed to update: HTTP {response.status}",
-                    "detail": error_data,  # Pass the full error structure to frontend
-                }
-    except Exception as e:
-        _logger.exception("Failed to update MAM ID in Prowlarr")
-        return {"success": False, "message": f"Error: {e!s}"}
+    """Update the MAM ID on a Prowlarr indexer."""
+    return await update_mam_id(PROWLARR, host, port, api_key, indexer_id, new_mam_id)
 
 
 async def sync_mam_id_to_prowlarr(session_cfg: dict[str, Any], mam_id: str) -> dict[str, Any]:
-    """High-level function to sync MAM ID to Prowlarr with auto-detection.
-
-    This is the main entry point for updating Prowlarr. It:
-    1. Validates Prowlarr config exists in session
-    2. Auto-detects MAM indexer ID (every time, as requested)
-    3. Updates the MAM ID
-
-    Args:
-        session_cfg: Session configuration dict with prowlarr settings
-        mam_id: New MAM ID to sync
-
-    Returns:
-        dict with success, message, and optional details
-    """
-    prowlarr_cfg = session_cfg.get("prowlarr", {})
-
-    # Validate required config
-    if not prowlarr_cfg.get("enabled", False):
-        return {
-            "success": False,
-            "message": "Prowlarr integration is not enabled for this session. Please enable Prowlarr and save your session.",
-        }
-
-    host = prowlarr_cfg.get("host", "").strip()
-    port = prowlarr_cfg.get("port")
-    api_key = prowlarr_cfg.get("api_key", "").strip()
-
-    if not all([host, port, api_key]):
-        return {
-            "success": False,
-            "message": "Prowlarr configuration incomplete. Please configure host, port, and API key, then save your session before updating.",
-        }
-
-    # Auto-detect MAM indexer ID
-    _logger.info("Auto-detecting MAM indexer ID in Prowlarr...")
-    find_result = await find_mam_indexer_id(host, port, api_key)
-    if not find_result["success"]:
-        return find_result
-
-    indexer_id = find_result["indexer_id"]
-
-    # Update MAM ID
-    return await update_mam_id_in_prowlarr(host, port, api_key, indexer_id, mam_id)
+    """Sync the MAM ID to Prowlarr, auto-detecting the indexer each time."""
+    return await sync_mam_id(PROWLARR, session_cfg, mam_id)

--- a/backend/servarr_client.py
+++ b/backend/servarr_client.py
@@ -1,0 +1,339 @@
+"""Shared client for Servarr-style indexer services (Prowlarr, Chaptarr).
+
+Both services expose the same `/api/v1/indexer` API and were implemented as
+near-identical modules — 91.5% of their lines matched once the service name was
+normalised. This holds the one implementation; the per-service modules supply a
+:class:`ServarrService` describing where they genuinely differ and keep their
+existing public functions as thin wrappers.
+
+The differences are deliberately narrow and each is load-bearing:
+
+- **How the MAM indexer is recognised.** Prowlarr matches ``definitionName``
+  exactly; Chaptarr matches ``implementation`` case-insensitively.
+- **Whether the update forces a save.** Chaptarr appends ``?forceSave=true``.
+- **The spelling used in messages.** Prowlarr says "MyAnonamouse", Chaptarr
+  says "MyAnonaMouse", and both spellings are user-visible.
+
+The MAM ID field itself is ``mamId`` on both, lowercase. Chaptarr shipped with
+``MamId`` and it failed with "MAM ID field not found" until 4e08272f corrected
+it; the match is exact rather than case-insensitive on both services.
+"""
+
+from dataclasses import dataclass
+import json
+import logging
+from typing import Any
+
+import aiohttp
+
+from backend.url_builder import build_service_url
+
+_logger: logging.Logger = logging.getLogger(__name__)
+_TIMEOUT = aiohttp.ClientTimeout(total=10)
+
+# The MAM ID field is spelled the same on every Servarr service.
+MAM_ID_FIELD = "mamId"
+
+
+@dataclass(frozen=True)
+class ServarrService:
+    """Describes how one Servarr-style service differs from the others.
+
+    Attributes:
+        name: Display name used in messages and log lines.
+        config_key: Key holding this service's settings in a session config.
+        indexer_match_field: Indexer field naming the implementation.
+        indexer_label: Spelling of the MAM indexer in user-visible messages.
+        match_case_insensitive: Whether the indexer match ignores case.
+        force_save: Whether the update PUT appends ``?forceSave=true``.
+
+    """
+
+    name: str
+    config_key: str
+    indexer_match_field: str
+    indexer_label: str
+    match_case_insensitive: bool
+    force_save: bool
+
+
+async def test_connection(
+    service: ServarrService, host: str, port: int, api_key: str
+) -> dict[str, Any]:
+    """Test connectivity and report how many indexers the service has.
+
+    Args:
+        service: Service description.
+        host: Service host.
+        port: Service port.
+        api_key: Service API key.
+
+    Returns:
+        dict with ``success``, ``message`` and, on success, ``indexer_count``.
+
+    """
+    url = build_service_url(host, port, "/api/v1/indexer")
+    headers = {"X-Api-Key": api_key}
+
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(url, headers=headers, timeout=_TIMEOUT) as response,
+        ):
+            if response.status == 200:
+                indexers = await response.json()
+                return {
+                    "success": True,
+                    "message": f"Connected successfully. Found {len(indexers)} indexer(s).",
+                    "indexer_count": len(indexers),
+                }
+            if response.status == 401:
+                return {"success": False, "message": "Authentication failed. Check API key."}
+
+            return {"success": False, "message": f"Connection failed: HTTP {response.status}"}
+    except TimeoutError:
+        return {"success": False, "message": "Connection timeout"}
+    except Exception as e:
+        _logger.error("%s connection test failed: %s", service.name, e)
+        return {"success": False, "message": str(e)}
+
+
+def _is_mam_indexer(service: ServarrService, indexer: dict[str, Any]) -> bool:
+    """Return whether an indexer entry is the MAM indexer for this service."""
+    value = indexer.get(service.indexer_match_field, "")
+    if service.match_case_insensitive:
+        return str(value).lower() == service.indexer_label.lower()
+    return bool(value == service.indexer_label)
+
+
+async def find_indexer_id(
+    service: ServarrService, host: str, port: int, api_key: str
+) -> dict[str, Any]:
+    """Locate the MAM indexer's id by scanning the service's indexer list.
+
+    Args:
+        service: Service description.
+        host: Service host.
+        port: Service port.
+        api_key: Service API key.
+
+    Returns:
+        dict with ``success``, ``message`` and, when found, ``indexer_id``.
+
+    """
+    url = build_service_url(host, port, "/api/v1/indexer")
+    headers = {"X-Api-Key": api_key}
+
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(url, headers=headers, timeout=_TIMEOUT) as response,
+        ):
+            if response.status != 200:
+                return {
+                    "success": False,
+                    "message": f"Failed to fetch indexers: HTTP {response.status}",
+                }
+
+            indexers = await response.json()
+            for indexer in indexers:
+                if _is_mam_indexer(service, indexer):
+                    indexer_id = indexer.get("id")
+                    _logger.info(
+                        "Found MAM indexer in %s: id=%s, name=%s",
+                        service.name,
+                        indexer_id,
+                        indexer.get("name"),
+                    )
+                    return {
+                        "success": True,
+                        "indexer_id": indexer_id,
+                        "message": f"Found {service.indexer_label} indexer (ID: {indexer_id})",
+                    }
+
+            return {
+                "success": False,
+                "message": (
+                    f"{service.indexer_label} indexer not found in {service.name}. "
+                    "Please add it first."
+                ),
+            }
+
+    except Exception as e:
+        _logger.exception("Failed to find MAM indexer")
+        return {"success": False, "message": f"Error: {e!s}"}
+
+
+async def get_indexer_config(
+    service: ServarrService, host: str, port: int, api_key: str, indexer_id: int
+) -> dict[str, Any]:
+    """Fetch one indexer's full configuration.
+
+    Args:
+        service: Service description.
+        host: Service host.
+        port: Service port.
+        api_key: Service API key.
+        indexer_id: Indexer id to fetch.
+
+    Returns:
+        dict with ``success``, ``message`` and, on success, ``config``.
+
+    """
+    url = build_service_url(host, port, f"/api/v1/indexer/{indexer_id}")
+    headers = {"X-Api-Key": api_key}
+
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(url, headers=headers, timeout=_TIMEOUT) as response,
+        ):
+            if response.status == 200:
+                config = await response.json()
+                return {"success": True, "config": config, "message": "Success"}
+            if response.status == 404:
+                return {
+                    "success": False,
+                    "message": f"Indexer ID {indexer_id} not found.",
+                }
+            return {
+                "success": False,
+                "message": f"HTTP {response.status}: {response.reason}",
+            }
+    except Exception as e:
+        _logger.exception("Failed to fetch indexer config")
+        return {"success": False, "message": f"Error: {e!s}"}
+
+
+async def update_mam_id(
+    service: ServarrService,
+    host: str,
+    port: int,
+    api_key: str,
+    indexer_id: int,
+    new_mam_id: str,
+) -> dict[str, Any]:
+    """Rewrite the indexer's MAM ID field and save it back.
+
+    Args:
+        service: Service description.
+        host: Service host.
+        port: Service port.
+        api_key: Service API key.
+        indexer_id: Indexer id to update.
+        new_mam_id: MAM ID to write.
+
+    Returns:
+        dict with ``success``, ``message`` and, on success, ``old_mam_id``.
+
+    """
+    get_result = await get_indexer_config(service, host, port, api_key, indexer_id)
+    if not get_result["success"]:
+        return get_result
+
+    config = get_result["config"]
+
+    old_mam_id = None
+    mam_id_found = False
+    for field in config.get("fields", []):
+        if field.get("name") == MAM_ID_FIELD:
+            old_mam_id = field.get("value", "")
+            field["value"] = new_mam_id
+            mam_id_found = True
+            _logger.info("Updating MAM ID in %s: %s -> %s", service.name, old_mam_id, new_mam_id)
+            break
+
+    if not mam_id_found:
+        return {
+            "success": False,
+            "message": "MAM ID field not found in indexer configuration.",
+        }
+
+    path = f"/api/v1/indexer/{indexer_id}"
+    if service.force_save:
+        path += "?forceSave=true"
+    url = build_service_url(host, port, path)
+    headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
+
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.put(url, headers=headers, json=config, timeout=_TIMEOUT) as response,
+        ):
+            if response.status in (200, 202):
+                _logger.info(
+                    "Successfully updated MAM ID in %s (indexer %s)", service.name, indexer_id
+                )
+                return {
+                    "success": True,
+                    "message": (
+                        f"MAM ID updated successfully in {service.name} (indexer {indexer_id})"
+                    ),
+                    "old_mam_id": old_mam_id,
+                }
+
+            # Parse the error body as JSON where possible so the frontend can
+            # show the service's own validation detail rather than raw text.
+            error_text = await response.text()
+            try:
+                error_data = json.loads(error_text)
+            except json.JSONDecodeError:
+                return {
+                    "success": False,
+                    "message": f"Failed to update: HTTP {response.status} - {error_text}",
+                }
+            else:
+                return {
+                    "success": False,
+                    "message": f"Failed to update: HTTP {response.status}",
+                    "detail": error_data,
+                }
+    except Exception as e:
+        _logger.exception("Failed to update MAM ID in %s", service.name)
+        return {"success": False, "message": f"Error: {e!s}"}
+
+
+async def sync_mam_id(
+    service: ServarrService, session_cfg: dict[str, Any], mam_id: str
+) -> dict[str, Any]:
+    """Detect the MAM indexer and write a new MAM ID to it.
+
+    Args:
+        service: Service description.
+        session_cfg: Session configuration holding this service's settings.
+        mam_id: MAM ID to sync.
+
+    Returns:
+        dict with ``success`` and ``message``.
+
+    """
+    service_cfg = session_cfg.get(service.config_key, {})
+
+    if not service_cfg.get("enabled", False):
+        return {
+            "success": False,
+            "message": (
+                f"{service.name} integration is not enabled for this session. "
+                f"Please enable {service.name} and save your session."
+            ),
+        }
+
+    host = service_cfg.get("host", "").strip()
+    port = service_cfg.get("port")
+    api_key = service_cfg.get("api_key", "").strip()
+
+    if not all([host, port, api_key]):
+        return {
+            "success": False,
+            "message": (
+                f"{service.name} configuration incomplete. Please configure host, port, "
+                "and API key, then save your session before updating."
+            ),
+        }
+
+    _logger.info("Auto-detecting MAM indexer ID in %s...", service.name)
+    find_result = await find_indexer_id(service, host, port, api_key)
+    if not find_result["success"]:
+        return find_result
+
+    return await update_mam_id(service, host, port, api_key, find_result["indexer_id"], mam_id)

--- a/tests/backend/test_servarr_integrations.py
+++ b/tests/backend/test_servarr_integrations.py
@@ -14,7 +14,7 @@ from typing import Any, Self
 
 import pytest
 
-from backend import chaptarr_integration, prowlarr_integration
+from backend import chaptarr_integration, prowlarr_integration, servarr_client
 
 HOST = "svc.local"
 PORT = 9696
@@ -84,9 +84,17 @@ class _StubSession:
 def _install(
     monkeypatch: pytest.MonkeyPatch, module: Any, responses: dict[str, _StubResponse]
 ) -> _StubSession:
-    """Point a module's ``aiohttp.ClientSession`` at a stub and return it."""
+    """Point the shared client's ``aiohttp.ClientSession`` at a stub.
+
+    The `module` argument is retained so each test still names the integration
+    it exercises. The patch target is `servarr_client`, which is where the
+    HTTP calls live now that Prowlarr and Chaptarr share one implementation;
+    only this seam moved, and no assertion in this file changed with it.
+    """
     session = _StubSession(responses)
-    monkeypatch.setattr(module.aiohttp, "ClientSession", lambda *a, **k: session, raising=True)
+    monkeypatch.setattr(
+        servarr_client.aiohttp, "ClientSession", lambda *a, **k: session, raising=True
+    )
     return session
 
 


### PR DESCRIPTION
`prowlarr_integration` and `chaptarr_integration` were 91.5% identical —
264 of ~280 lines matched once the service name was normalised, and pylint
reported an 88-line common block. Both drive the same `/api/v1/indexer`
API. This moves the implementation into `servarr_client` and reduces each
module to a service description plus the wrappers the app imports.

The two modules genuinely differed in exactly three ways, and each is now a
field on `ServarrService` rather than a divergent copy:

- **Indexer match.** Prowlarr matches `definitionName` against
  "MyAnonamouse" exactly; Chaptarr matches `implementation` against
  "MyAnonaMouse" case-insensitively.
- **Save semantics.** Chaptarr's update PUTs to `?forceSave=true`.
- **Message spelling.** The two spellings of the indexer name are
  user-visible and are preserved per service.

The MAM ID field is `mamId` on both, matched exactly. Chaptarr originally
shipped `MamId` and failed with "MAM ID field not found" until 4e08272f
corrected the case; the module docstring still described the pre-fix
spelling and has been corrected here.

**On the test evidence.** The characterisation tests added in #114 pass
against this change with every assertion unchanged, including the ones
pinning the exact-versus-case-insensitive match and the `forceSave`
difference. One line of the harness did change: they patch
`servarr_client.aiohttp` rather than each module's `aiohttp`, because that
is where the HTTP calls now live. That is the seam moving, not behaviour;
no assertion was touched, and the tests failed loudly on the old patch
target rather than silently passing.

Measured, not assumed. jscpd falls from 218 clones over 2112 lines (11.75%)
to 208 over 1953 (10.94%), and pylint's duplicate-code check no longer
reports any finding naming either module. The two modules go from 577 lines
to 450 including the new shared one. Coverage of both rises to 85%.

Validated: `./scripts/lint.sh` clean on all 16 hooks, full backend suite
passes, total coverage 44.85%.