### PR TITLE
chore(mypy): enable warn_return_any and make the annotations true

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -226,11 +226,11 @@ def get_auto_update_val(status: dict[str, Any]) -> str:
             # If reason is present, append it for clarity
             if reason:
                 return f"{msg} ({reason})"
-            return msg
+            return str(msg)
         if error:
             if reason:
                 return f"{error} ({reason})"
-            return error
+            return str(error)
         return "N/A"
     return str(val)
 

--- a/backend/ip_lookup.py
+++ b/backend/ip_lookup.py
@@ -27,7 +27,8 @@ from backend.utils import build_proxy_dict
 
 _logger: logging.Logger = logging.getLogger(__name__)
 # Simple cache to prevent duplicate rapid requests (reduce 403 errors)
-_ip_cache: dict[str, Any] = {}
+# Maps a cache key to the normalised result and the time it was stored.
+_ip_cache: dict[str, tuple[dict[str, Any], float]] = {}
 _cache_timeout = 300  # Cache for 5 minutes to reduce rate limiting
 # Track last time we emitted a cache-hit debug log for a given cache key so
 # we don't flood logs when the frontend polls frequently.

--- a/backend/jackett_integration.py
+++ b/backend/jackett_integration.py
@@ -222,6 +222,13 @@ async def get_indexer_config(
         ):
             if response.status == 200:
                 config = await response.json()
+                if not isinstance(config, list):
+                    _logger.error(
+                        "Jackett returned %s for %s config, expected a list",
+                        type(config).__name__,
+                        indexer_name,
+                    )
+                    return None
                 _logger.info("Retrieved config for %s", indexer_name)
                 return config
 

--- a/backend/last_session_api.py
+++ b/backend/last_session_api.py
@@ -27,7 +27,7 @@ def read_last_session() -> str | None:
     Raises:
         YamlStoreError: If the existing settings file is invalid.
     """
-    data = load_yaml_file(LAST_SESSION_FILE, {}, expected_type=dict)
+    data: dict[str, Any] = load_yaml_file(LAST_SESSION_FILE, {}, expected_type=dict)
     return data.get("label")
 
 

--- a/backend/mam_api.py
+++ b/backend/mam_api.py
@@ -267,4 +267,9 @@ async def get_mam_seen_ip_info(mam_id: str, proxy_cfg: dict[str, Any]) -> dict[s
     except Exception as e:
         return {"error": f"Failed to fetch MAM-seen IP info: {e}"}
     else:
+        if not isinstance(data, dict):
+            # Callers index this like a mapping. Reporting the shape through the
+            # function's existing error convention beats handing back a list and
+            # failing with an AttributeError somewhere downstream.
+            return {"error": f"MAM returned {type(data).__name__}, expected an object"}
         return data

--- a/backend/port_monitor.py
+++ b/backend/port_monitor.py
@@ -141,7 +141,7 @@ class PortMonitorStackManager:
         configuration; malformed stack entries are logged and ignored.
         """
         self._config_loaded = False
-        data = load_yaml_file(PORT_MONITOR_CONFIG_PATH, [], expected_type=list)
+        data: list[Any] = load_yaml_file(PORT_MONITOR_CONFIG_PATH, [], expected_type=list)
 
         try:
             seen = set()

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -64,7 +64,7 @@ def build_status_message(status: dict, ip_monitoring_mode: str = "auto") -> str:
         return f"Error: {status['error']}"
     # If a static message is present (from mam_api or other), use it
     if status.get("message"):
-        return status["message"]
+        return str(status["message"])
 
     # Mode-specific status messages
     if ip_monitoring_mode == "static":
@@ -79,7 +79,7 @@ def build_status_message(status: dict, ip_monitoring_mode: str = "auto") -> str:
         if isinstance(result, dict):
             if result.get("success"):
                 return "IP Changed. Seedbox IP updated."
-            return result.get("error", "Seedbox update failed.")
+            return str(result.get("error", "Seedbox update failed."))
     return "No change detected. Update not needed."
 
 

--- a/backend/yaml_store.py
+++ b/backend/yaml_store.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 import os
 from pathlib import Path
 import tempfile
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -15,11 +15,11 @@ class YamlStoreError(RuntimeError):
     """Raised when YAML persistence cannot satisfy its file contract."""
 
 
-def load_yaml_file(
+def load_yaml_file[T](
     path: Path,
-    default: Any,
+    default: T,
     expected_type: type[Any] | tuple[type[Any], ...] | None = None,
-) -> Any:
+) -> T:
     """Load one YAML file.
 
     Args:
@@ -52,7 +52,10 @@ def load_yaml_file(
             f"YAML file {path} has top-level type {type(data).__name__}; "
             f"expected {_type_name(expected_type)}"
         )
-    return data
+    # `data` is Any out of yaml.safe_load. When `expected_type` was supplied the
+    # isinstance check above has already rejected anything else, and every call
+    # site pairs it with a matching `default`, which is what binds T.
+    return cast("T", data)
 
 
 def write_yaml_file(path: Path, data: Any) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
-warn_return_any = false
+warn_return_any = true
 warn_unreachable = true
 
 [tool.ruff]

--- a/tests/backend/test_mam_api.py
+++ b/tests/backend/test_mam_api.py
@@ -145,3 +145,44 @@ async def test_returns_none_without_a_request_when_no_proxy_is_configured(
 
     assert result is None
     assert session.requests == []
+
+
+async def test_mam_seen_ip_info_reports_a_non_object_response() -> None:
+    """A JSON array from MAM is reported, not handed back as a mapping.
+
+    `get_mam_seen_ip_info` declares a dict and its callers index it like one, so
+    a list would previously have surfaced as an AttributeError somewhere
+    downstream rather than as this function's own error.
+    """
+
+    class _ListResponse:
+        status = 200
+
+        async def json(self) -> Any:
+            return ["not", "an", "object"]
+
+        async def text(self) -> str:
+            return "[]"
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            """Leave the response context."""
+
+    class _Session:
+        def get(self, *_args: Any, **_kwargs: Any) -> _ListResponse:
+            return _ListResponse()
+
+        async def __aenter__(self) -> Self:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            """Leave the session context."""
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(mam_api.aiohttp, "ClientSession", lambda **_k: _Session(), raising=True)
+        result = await mam_api.get_mam_seen_ip_info("cookie", proxy_cfg={})
+
+    assert "error" in result
+    assert "list" in result["error"]

--- a/tests/backend/test_port_monitor.py
+++ b/tests/backend/test_port_monitor.py
@@ -480,7 +480,7 @@ def test_restart_stops_side_effects_when_shutdown_occurs_during_polling(
 
     def stop_during_check(*args: object) -> bool:
         manager.stop()
-        return check_port(*args)
+        return bool(check_port(*args))
 
     monkeypatch.setattr(manager, "restart_container", restart_container)
     monkeypatch.setattr(manager, "check_port", stop_during_check)


### PR DESCRIPTION
`warn_return_any` reported thirteen functions handing back `Any` where they
promise a concrete type. Rather than casting at each return, most are fixed
at the source.

**`load_yaml_file` is the root cause of five of them.** It already validated
its result with `isinstance(data, expected_type)` but was declared
`-> Any`, so every caller's `dict[str, Any]` promise was unbacked. It is now
generic on `default`, using PEP 695 syntax, and the five callers get the
type the runtime check already guaranteed. The one remaining `Any` is
internal, where `yaml.safe_load`'s result is returned after that check; it
is a documented `cast` rather than a silent one. Two call sites passing a
bare `{}` / `[]` needed an explicit annotation, since an empty literal
cannot bind the parameter on its own.

**`_ip_cache` was under-typed.** Declared `dict[str, Any]` while every use
unpacks `(result, stored_at)`, so it is now
`dict[str, tuple[dict[str, Any], float]]` and the cached-result return
needs no coercion.

**Four returns are coerced with `str()`** in `build_status_message` and
`get_auto_update_val`, where the value comes out of a status mapping and the
function promises `str`. `str(val)` was already the idiom on the last line
of `get_auto_update_val`, so this makes the rest of the function consistent.

**Two returns are unvalidated external JSON and are now checked**, which is
a behaviour change rather than a typing one:

- `get_mam_seen_ip_info` promises a mapping and its callers index it as one.
  A JSON array previously came straight back and failed later as an
  `AttributeError`; it is now reported through the function's own existing
  `{"error": ...}` convention.
- Jackett's `get_indexer_config` promises `list | None` and documents "None
  otherwise". A non-list response is now logged and returns `None`, matching
  that contract.

The first has a test, negative-controlled: reverting the check makes it
fail. Total coverage rises to 45.06%.

Validated: `./scripts/lint.sh` clean on all 16 hooks, backend suite passes.