### PR TITLE
fix(app): bind cfg before the try that can fail before assigning it

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1640,6 +1640,14 @@ async def api_save_session(request: Request) -> dict[str, Any]:
     global session_status_cache
 
     saved = False
+    # Bound before the try so the failure handler below can read it even when
+    # request.json() is what raised. `saved` only becomes True well after cfg is
+    # assigned, so cfg.get(...) in that handler was already unreachable while cfg
+    # was unbound — but the correlation lived in two variables, which is the kind
+    # of thing a later edit quietly breaks. Annotated `Any` to match what
+    # request.json() returns; typing it as a mapping here would change how the
+    # rest of the function is checked, which is a separate change.
+    cfg: Any = {}
     try:
         cfg = await request.json()
         old_label = cfg.get("old_label")


### PR DESCRIPTION
pyright reports `"cfg" is possibly unbound` at `app.py:1771`. In
`api_save_session`, `cfg = await request.json()` is the first statement
inside the `try`, so a malformed request body raises before cfg exists —
while the failure handler reads `cfg.get("label")`.

It is not a live crash today. That read sits behind `if saved:`, and
`saved` only becomes True at :1711, long after cfg is assigned at :1644, so
the handler cannot reach the read while cfg is unbound. But the guarantee
was held across two variables with nothing tying them together, which is
exactly the kind of invariant an ordinary edit breaks silently. Binding cfg
before the `try` makes it explicit.

Annotated `Any` rather than `dict[str, Any]` deliberately. `cfg` is
`request.json()`'s result and has always been `Any`; typing it as a mapping
changes how the rest of the function is checked and surfaces four further
errors, all from `label = cfg.get("label")` being passed to callees that
require `str`. That is a real latent problem — a save with no `label` in the
body reaches `get_session_path(None)` and would write `session-None.yaml` —
but fixing it needs a guard that raises `HTTPException`, which this
function's blanket `except Exception` would currently turn into a 500. That
is a separate change and is left alone here.

Pre-existing rather than introduced: the same pyright error is present at
v2.4.0 and v2.4.1.

Worth noting that nothing was watching for this. pyright is configured in
`pyproject.toml` but appears in neither `prek.toml` nor any workflow, so it
runs only in an editor. Repo-wide it now reports 0 errors, so adding it as a
gate is cheap — though it would need the `additional_dependencies` treatment
mypy already has, since the Linters job installs no Python packages.

Validated: `./scripts/lint.sh` clean on all 16 hooks, backend suite passes,
pyright and mypy both clean.