### PR TITLE
refactor(api): validate indexer test bodies with a typed model

### DIFF
--- a/backend/api_models.py
+++ b/backend/api_models.py
@@ -1,0 +1,38 @@
+"""Typed request bodies for the JSON API.
+
+Endpoints here historically read `await request.json()` and pulled fields out
+with `data.get(...)`, which left the shape unvalidated at the boundary. Two
+defects came from that: a non-numeric `weeks` reaching a live MAM purchase, and
+a port arriving as a string so that `"443"` selected `http` instead of `https`.
+
+Models are validated explicitly rather than bound as FastAPI parameters, so a
+bad body still answers 200 with `{"success": false, ...}` as these endpoints
+always have. Binding them as parameters would return 422 instead, and the
+frontend reads several of these responses without checking the status code.
+"""
+
+from typing import Annotated
+
+from pydantic import BaseModel, BeforeValidator, Field
+
+
+def _strip(value: object) -> object:
+    """Strip surrounding whitespace, leaving non-strings for the field to reject."""
+    return value.strip() if isinstance(value, str) else value
+
+
+StrippedStr = Annotated[str, BeforeValidator(_strip)]
+
+
+class IndexerTestRequest(BaseModel):
+    """Connection-test body shared by every indexer test endpoint.
+
+    `port` is declared `int`, so Pydantic converts a numeric string and rejects
+    anything else. That is what `coerce_port` was doing defensively at each of
+    these call sites, done once and rejecting garbage rather than passing it on.
+    """
+
+    host: Annotated[StrippedStr, Field(min_length=1)]
+    port: int
+    api_key: Annotated[StrippedStr, Field(min_length=1)]
+    admin_password: StrippedStr = ""

--- a/backend/app.py
+++ b/backend/app.py
@@ -23,10 +23,12 @@ from apscheduler.schedulers.background import BackgroundScheduler  # type: ignor
 from apscheduler.triggers.interval import IntervalTrigger  # type: ignore[import-untyped]
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.staticfiles import StaticFiles
+from pydantic import ValidationError
 from starlette.responses import FileResponse
 
 from backend.api_automation import router as automation_router
 from backend.api_event_log import router as event_log_router
+from backend.api_models import IndexerTestRequest
 from backend.api_notifications import router as notifications_router
 from backend.api_port_monitor import router as port_monitor_router
 from backend.api_proxy import router as proxy_router
@@ -2128,10 +2130,11 @@ async def api_prowlarr_test(request: Request) -> dict[str, Any]:
     Expects JSON with: host, port, api_key
     """
     try:
-        data = await request.json()
-        host = data.get("host", "").strip()
-        port = coerce_port(data.get("port"))
-        api_key = data.get("api_key", "").strip()
+        try:
+            payload = IndexerTestRequest.model_validate(await request.json())
+        except ValidationError:
+            return {"success": False, "message": "Missing required fields"}
+        host, port, api_key = payload.host, payload.port, payload.api_key
 
         _logger.debug(
             "[Prowlarr] Test connection request - host: %s, port: %s (type: %s), api_key: %s",
@@ -2140,9 +2143,6 @@ async def api_prowlarr_test(request: Request) -> dict[str, Any]:
             type(port).__name__,
             "***" + api_key[-4:] if api_key and len(api_key) > 4 else "***",
         )
-
-        if not host or port is None or not api_key:
-            return {"success": False, "message": "Missing required fields"}
 
         # Test connection and find MAM indexer
         conn_result = await test_prowlarr_connection(host, port, api_key)
@@ -2179,13 +2179,11 @@ async def api_prowlarr_find_indexer(request: Request) -> dict[str, Any]:
     Expects JSON with: host, port, api_key
     """
     try:
-        data = await request.json()
-        host = data.get("host", "").strip()
-        port = coerce_port(data.get("port"))
-        api_key = data.get("api_key", "").strip()
-
-        if not all([host, port, api_key]):
+        try:
+            payload = IndexerTestRequest.model_validate(await request.json())
+        except ValidationError:
             return {"success": False, "message": "Missing required fields"}
+        host, port, api_key = payload.host, payload.port, payload.api_key
 
         return await find_mam_indexer_id(host, port, api_key)
     except Exception as e:
@@ -2245,10 +2243,11 @@ async def api_chaptarr_test(request: Request) -> dict[str, Any]:
     Expects JSON with: host, port, api_key
     """
     try:
-        data = await request.json()
-        host = data.get("host", "").strip()
-        port = coerce_port(data.get("port"))
-        api_key = data.get("api_key", "").strip()
+        try:
+            payload = IndexerTestRequest.model_validate(await request.json())
+        except ValidationError:
+            return {"success": False, "message": "Missing required fields"}
+        host, port, api_key = payload.host, payload.port, payload.api_key
 
         _logger.debug(
             "[Chaptarr] Test connection request - host: %s, port: %s (type: %s), api_key: %s",
@@ -2257,9 +2256,6 @@ async def api_chaptarr_test(request: Request) -> dict[str, Any]:
             type(port).__name__,
             "***" + api_key[-4:] if api_key and len(api_key) > 4 else "***",
         )
-
-        if not host or port is None or not api_key:
-            return {"success": False, "message": "Missing required fields"}
 
         # Test connection and find MAM indexer
         conn_result = await test_chaptarr_connection(host, port, api_key)
@@ -2341,20 +2337,18 @@ async def api_jackett_test(request: Request) -> dict[str, Any]:
     Expects JSON with: host, port, api_key, admin_password
     """
     try:
-        data = await request.json()
-        host = data.get("host", "").strip()
-        port = coerce_port(data.get("port"))
-        api_key = data.get("api_key", "").strip()
-        admin_password = data.get("admin_password", "").strip()
+        try:
+            payload = IndexerTestRequest.model_validate(await request.json())
+        except ValidationError:
+            return {"success": False, "message": "Missing required fields (host, port, api_key)"}
+        host, port, api_key = payload.host, payload.port, payload.api_key
+        admin_password = payload.admin_password
 
         _logger.debug(
             "[Jackett] Test connection request - host: %s, port: %s",
             host,
             port,
         )
-
-        if not host or port is None or not api_key:
-            return {"success": False, "message": "Missing required fields (host, port, api_key)"}
 
         # Test API connection with optional authentication
         return await test_jackett_connection(host, port, api_key, admin_password or "")
@@ -2431,19 +2425,17 @@ async def api_audiobookrequest_test(request: Request) -> dict[str, Any]:
     Expects JSON with: host, port, api_key
     """
     try:
-        data = await request.json()
-        host = data.get("host", "").strip()
-        port = coerce_port(data.get("port"))
-        api_key = data.get("api_key", "").strip()
+        try:
+            payload = IndexerTestRequest.model_validate(await request.json())
+        except ValidationError:
+            return {"success": False, "message": "Missing required fields (host, port, api_key)"}
+        host, port, api_key = payload.host, payload.port, payload.api_key
 
         _logger.debug(
             "[AudioBookRequest] Test connection request - host: %s, port: %s",
             host,
             port,
         )
-
-        if not host or port is None or not api_key:
-            return {"success": False, "message": "Missing required fields (host, port, api_key)"}
 
         return await test_audiobookrequest_connection(host, port, api_key)
     except Exception as e:
@@ -2518,19 +2510,17 @@ async def api_autobrr_test(request: Request) -> dict[str, Any]:
     Expects JSON with: host, port, api_key
     """
     try:
-        data = await request.json()
-        host = data.get("host", "").strip()
-        port = coerce_port(data.get("port"))
-        api_key = data.get("api_key", "").strip()
+        try:
+            payload = IndexerTestRequest.model_validate(await request.json())
+        except ValidationError:
+            return {"success": False, "message": "Missing required fields (host, port, api_key)"}
+        host, port, api_key = payload.host, payload.port, payload.api_key
 
         _logger.debug(
             "[Autobrr] Test connection request - host: %s, port: %s",
             host,
             port,
         )
-
-        if not host or port is None or not api_key:
-            return {"success": False, "message": "Missing required fields (host, port, api_key)"}
 
         return await test_autobrr_connection(host, port, api_key)
     except Exception as e:

--- a/tests/backend/test_api_models.py
+++ b/tests/backend/test_api_models.py
@@ -1,0 +1,62 @@
+"""Tests for the typed request bodies used by the JSON API."""
+
+from pydantic import ValidationError
+import pytest
+
+from backend.api_models import IndexerTestRequest
+
+
+@pytest.mark.parametrize(
+    ("raw_port", "expected"),
+    [(9117, 9117), ("9117", 9117), ("443", 443), (443, 443)],
+)
+def test_port_accepts_a_number_however_it_is_spelled(raw_port: object, expected: int) -> None:
+    """A quoted port resolves to the same integer as an unquoted one.
+
+    This is the defect behind the `coerce_port` helper: `"443"` compares
+    unequal to `443`, so the URL builder chose http for a TLS service.
+    """
+    model = IndexerTestRequest(host="h", port=raw_port, api_key="k")  # type: ignore[arg-type]
+
+    assert model.port == expected
+    assert isinstance(model.port, int)
+
+
+@pytest.mark.parametrize("raw_port", ["abc", "", None, "44a3", [], {}])
+def test_port_rejects_anything_that_is_not_a_number(raw_port: object) -> None:
+    """A port that is not a number is refused at the boundary.
+
+    `coerce_port` passed these through unchanged, so `"abc"` reached the URL
+    builder and produced `http://host:abc`.
+    """
+    with pytest.raises(ValidationError):
+        IndexerTestRequest(host="h", port=raw_port, api_key="k")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(("field", "value"), [("host", ""), ("host", "   "), ("api_key", "")])
+def test_required_strings_reject_blank_values(field: str, value: str) -> None:
+    """Host and API key must survive stripping, matching the old `not host` guard."""
+    body: dict[str, object] = {"host": "h", "port": 9117, "api_key": "k", field: value}
+
+    with pytest.raises(ValidationError):
+        IndexerTestRequest.model_validate(body)
+
+
+def test_surrounding_whitespace_is_stripped() -> None:
+    """Values are stripped, as the previous `.strip()` calls did."""
+    # S106: a placeholder for the strip assertion, not a credential.
+    model = IndexerTestRequest(
+        host="  h  ",
+        port=9117,
+        api_key="  k  ",
+        admin_password="  p  ",  # noqa: S106
+    )
+
+    assert (model.host, model.api_key, model.admin_password) == ("h", "k", "p")
+
+
+def test_admin_password_is_optional_and_defaults_to_empty() -> None:
+    """Jackett auth is optional; omitting the password is valid and yields ''."""
+    model = IndexerTestRequest(host="h", port=9117, api_key="k")
+
+    assert model.admin_password == ""


### PR DESCRIPTION
Six endpoints parsed their request body by hand — `data.get("host", "")`,
`coerce_port(data.get("port"))`, `data.get("api_key", "")` — repeated
character for character, each followed by its own
`if not host or port is None or not api_key` guard. That shape is where two
defects came from: a port arriving as a string so `"443"` selected `http`
for a TLS service, and a non-numeric `weeks` reaching a live MAM purchase.

Adds `backend/api_models.py` with `IndexerTestRequest`, and replaces the six
hand-rolled parses with one validated model. The five guards it makes
unreachable are removed; `redundant-expr`, enabled in #112, is what proved
they were dead rather than my reading of them.

**The model is validated explicitly, not bound as a FastAPI parameter.**
Binding it would answer 422 on a bad body; these endpoints have always
answered 200 with `{"success": false, "message": ...}`, and the frontend
reads several responses without checking the status code — `App.jsx`'s
`loadSession` calls `res.json()` with no `res.ok` test. Each endpoint keeps
its own existing message, including the two spellings already in use.

**One behaviour change, an improvement.** `port` is declared `int`, so
Pydantic converts a numeric string and *rejects* anything else. `coerce_port`
passed non-numeric values through unchanged, so `"abc"` reached the URL
builder and produced `http://host:abc`; it is now refused at the boundary
with the endpoint's missing-fields message. Verified end to end against a
running app: an int port and `"9117"` both proceed to the connection
attempt, while a missing port, a blank host and `"abc"` are all refused.

`coerce_port` stays for the ten remaining call sites, which read ports from
session YAML rather than a request body and are not covered by this model.
The `all([host, port, api_key])` guards on those paths are untouched and
were checked individually — only guards on values the model now guarantees
were removed.

Fifteen tests cover the model. Coverage rises to 45.27%.

Validated: `./scripts/lint.sh` clean on all 16 hooks, backend suite passes,
mypy and pyright both clean.