### PR TITLE
fix(app): refuse a session save with no usable label as a 400

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1712,6 +1712,10 @@ async def api_save_session(request: Request) -> dict[str, Any]:
                     cfg[field] = prev_cfg[field]
 
         label = cfg.get("label")
+        if not isinstance(label, str) or not label.strip():
+            raise HTTPException(
+                status_code=400, detail="Session label is required to save a session."
+            )
         session_path = get_session_path(label)
         is_new = not Path(session_path).exists()
 
@@ -1771,6 +1775,10 @@ async def api_save_session(request: Request) -> dict[str, Any]:
         prev_mam_id = prev_cfg.get("mam", {}).get("mam_id") if prev_cfg else None
         await _sync_integrations_if_mam_id_changed(cfg, label, new_mam_id, prev_mam_id)
 
+    except HTTPException:
+        # A deliberate status from this handler (a 400 for a bad body, say) must
+        # not be re-wrapped as a 500 by the catch-all below.
+        raise
     except Exception as e:
         if saved:
             _logger.exception(

--- a/tests/backend/integration/test_session_save_label.py
+++ b/tests/backend/integration/test_session_save_label.py
@@ -1,0 +1,50 @@
+"""Backend integration tests for the session-save label requirement."""
+
+from pathlib import Path
+
+from httpx import AsyncClient
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("label", "case"),
+    [
+        (None, "explicit null"),
+        ("", "empty string"),
+        ("   ", "whitespace only"),
+    ],
+)
+async def test_saving_without_a_usable_label_is_a_client_error(
+    api_client: AsyncClient, isolated_backend: Path, label: object, case: str
+) -> None:
+    """A body with no usable label is refused as a 400 and writes nothing.
+
+    Two distinct defects are covered. A missing label previously reached
+    `save_session`, whose `ValueError` the blanket handler reported as a 500 —
+    a server error for a plainly malformed request. A whitespace-only label is
+    truthy, so it passed that guard entirely and created a session file named
+    `session-   .yaml`.
+    """
+    body: dict[str, object] = {"mam": {"mam_id": "x"}}
+    if label is not None or case == "explicit null":
+        body["label"] = label
+
+    response = await api_client.post("/api/session/save", json=body)
+
+    assert response.status_code == 400
+    assert "label" in response.json()["detail"].lower()
+    assert list(isolated_backend.glob("session-*.yaml")) == []
+
+
+@pytest.mark.integration
+async def test_saving_with_a_label_still_works(
+    api_client: AsyncClient, isolated_backend: Path
+) -> None:
+    """The guard does not disturb a normal save."""
+    response = await api_client.post(
+        "/api/session/save", json={"label": "seedbox", "mam": {"mam_id": "x"}}
+    )
+
+    assert response.json() == {"success": True}
+    assert [p.name for p in isolated_backend.glob("session-*.yaml")] == ["session-seedbox.yaml"]


### PR DESCRIPTION
`api_save_session` took `label` straight from the request body and used it
without checking it. Two distinct defects followed, both measured against
the previous code rather than inferred:

    POST /api/session/save {"mam": {...}}          # no label
      before: 500 {"detail": "Failed to save session: Session label is
                    required to save a session."}
      after:  400 {"detail": "Session label is required to save a session."}

    POST /api/session/save {"label": "   ", ...}   # whitespace only
      before: 200 {"success": true}, writing `session-   .yaml`
      after:  400, writing nothing

The second is the real one. `save_session` guards with `if not label`, and
`"   "` is truthy, so a whitespace-only label passed straight through and
created a session file named with spaces — awkward to select or delete from
the UI afterwards. The first is the 500-for-a-client-error shape already
fixed for the VIP endpoint in #98.

The guard validates the label before use. Raising an `HTTPException` from
inside this function's body needed the handler to stop flattening it: the
blanket `except Exception` re-wrapped every exception as a 500, including
deliberate statuses, so an `except HTTPException: raise` now precedes it.

**Correcting the record.** #117's commit message claims a save with no label
"reaches `get_session_path(None)` and would write `session-None.yaml`". That
is wrong, and I did not test it before writing it. `get_session_path` only
builds a `Path` and performs no I/O, and `save_session` rejects a falsy
label, so no file was ever written for that case — it failed as a 500. The
file-writing defect is real but belongs to the whitespace case above, which
that message did not describe.

Four tests, negative-controlled: the three guard cases fail against the
previous code and the normal-save case passes on both sides.

Validated: `./scripts/lint.sh` clean on all 16 hooks, backend suite passes,
mypy and pyright clean, coverage 45.29%.