### PR TITLE
ci: gate on pyright, which was configured but ran nowhere

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -103,6 +103,32 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  type-check:
+    name: Pyright
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      # [tool.pyright] resolves imports through .venv, so CI builds the same
+      # virtualenv a developer has rather than duplicating the dependency list
+      # the way the prek mypy hook has to.
+      - name: Install type-check dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install --group typecheck
+
+      - name: Run pyright
+        run: npx --yes pyright@1.1.413 backend
+
   linters:
     name: Run Linters
     runs-on: ubuntu-latest


### PR DESCRIPTION
`[tool.pyright]` has been in `pyproject.toml` all along, but pyright appears
in no hook and no workflow — it only ever ran in an editor. That is why the
`"cfg" is possibly unbound` error fixed in #117 sat in `app.py` through
v2.4.0 and v2.4.1 and was found by a human reading their IDE rather than by
CI. mypy does not report that class at all.

Adds a `Pyright` job. Repo-wide the checker is at 0 errors, so this gates
from the first run with no cleanup needed.

**On the dependency list.** The prek mypy hook has to restate twenty
packages in `additional_dependencies`, because prek runs each hook in its
own environment. Rather than copy that list, this job builds the `.venv`
that `[tool.pyright]` already points at and installs the `typecheck`
dependency group into it — the same group that defines those packages in one
place. The pyright config needs no CI-specific variant, and the list has one
owner.

pyright is pinned to 1.1.413. An unpinned checker changes what CI enforces
whenever upstream releases.

Verified rather than assumed, by reproducing the job in a clean tree: a
fresh venv plus `pip install --group typecheck` plus pinned pyright reports
0 errors. Negative-controlled too — an injected `possibly unbound` in
`url_builder` is reported and exits non-zero, so the gate is not inert.

Validated: actionlint clean.