### PR TITLE
refactor(api): validate indexer update bodies with a typed model

### DIFF
--- a/backend/api_models.py
+++ b/backend/api_models.py
@@ -36,3 +36,15 @@ class IndexerTestRequest(BaseModel):
     port: int
     api_key: Annotated[StrippedStr, Field(min_length=1)]
     admin_password: StrippedStr = ""
+
+
+class IndexerUpdateRequest(BaseModel):
+    """Body for the indexer update endpoints, which act on a saved session.
+
+    `mam_id` is optional: these endpoints fall back to the session's stored
+    value when the caller does not supply one, so an absent or blank value is
+    not an error here.
+    """
+
+    label: Annotated[StrippedStr, Field(min_length=1)]
+    mam_id: StrippedStr = ""

--- a/backend/app.py
+++ b/backend/app.py
@@ -28,7 +28,7 @@ from starlette.responses import FileResponse
 
 from backend.api_automation import router as automation_router
 from backend.api_event_log import router as event_log_router
-from backend.api_models import IndexerTestRequest
+from backend.api_models import IndexerTestRequest, IndexerUpdateRequest
 from backend.api_notifications import router as notifications_router
 from backend.api_port_monitor import router as port_monitor_router
 from backend.api_proxy import router as proxy_router
@@ -2208,17 +2208,18 @@ async def api_prowlarr_update(request: Request) -> dict[str, Any]:
     - mam_id: (optional) new MAM ID to sync. If not provided, uses session's MAM ID.
     """
     try:
-        data = await request.json()
-        label = data.get("label")
-        if not label:
+        try:
+            payload = IndexerUpdateRequest.model_validate(await request.json())
+        except ValidationError:
             return {"success": False, "message": "Session label required"}
+        label = payload.label
 
         if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
         cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
-        mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")
+        mam_id = payload.mam_id or cfg.get("mam", {}).get("mam_id", "")
         if not mam_id:
             return {
                 "success": False,
@@ -2302,17 +2303,18 @@ async def api_chaptarr_update(request: Request) -> dict[str, Any]:
     - mam_id: (optional) new MAM ID to sync. If not provided, uses session's MAM ID.
     """
     try:
-        data = await request.json()
-        label = data.get("label")
-        if not label:
+        try:
+            payload = IndexerUpdateRequest.model_validate(await request.json())
+        except ValidationError:
             return {"success": False, "message": "Session label required"}
+        label = payload.label
 
         if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
         cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
-        mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")
+        mam_id = payload.mam_id or cfg.get("mam", {}).get("mam_id", "")
         if not mam_id:
             return {
                 "success": False,
@@ -2374,17 +2376,18 @@ async def api_jackett_update(request: Request) -> dict[str, Any]:
     - mam_id: (optional) new MAM ID to sync. If not provided, uses session's MAM ID.
     """
     try:
-        data = await request.json()
-        label = data.get("label")
-        if not label:
+        try:
+            payload = IndexerUpdateRequest.model_validate(await request.json())
+        except ValidationError:
             return {"success": False, "message": "Session label required"}
+        label = payload.label
 
         if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
         cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
-        mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")
+        mam_id = payload.mam_id or cfg.get("mam", {}).get("mam_id", "")
         if not mam_id:
             return {
                 "success": False,
@@ -2460,17 +2463,18 @@ async def api_audiobookrequest_update(request: Request) -> dict[str, Any]:
     - mam_id: (optional) new MAM ID to sync. If not provided, uses session's MAM ID.
     """
     try:
-        data = await request.json()
-        label = data.get("label")
-        if not label:
+        try:
+            payload = IndexerUpdateRequest.model_validate(await request.json())
+        except ValidationError:
             return {"success": False, "message": "Session label required"}
+        label = payload.label
 
         if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
         cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
-        mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")
+        mam_id = payload.mam_id or cfg.get("mam", {}).get("mam_id", "")
         if not mam_id:
             return {
                 "success": False,
@@ -2545,17 +2549,18 @@ async def api_autobrr_update(request: Request) -> dict[str, Any]:
     - mam_id: (optional) new MAM ID to sync. If not provided, uses session's MAM ID.
     """
     try:
-        data = await request.json()
-        label = data.get("label")
-        if not label:
+        try:
+            payload = IndexerUpdateRequest.model_validate(await request.json())
+        except ValidationError:
             return {"success": False, "message": "Session label required"}
+        label = payload.label
 
         if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
         cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
-        mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")
+        mam_id = payload.mam_id or cfg.get("mam", {}).get("mam_id", "")
         if not mam_id:
             return {
                 "success": False,
@@ -2607,17 +2612,18 @@ async def api_indexer_update(request: Request) -> dict[str, Any]:
     - mam_id: (optional) new MAM ID to sync. If not provided, uses session's MAM ID.
     """
     try:
-        data = await request.json()
-        label = data.get("label")
-        if not label:
+        try:
+            payload = IndexerUpdateRequest.model_validate(await request.json())
+        except ValidationError:
             return {"success": False, "message": "Session label required"}
+        label = payload.label
 
         if not session_exists(label):
             return {"success": False, "message": f"Session '{label}' not found"}
         cfg = load_session(label)
 
         # Use provided mam_id or fall back to session config
-        mam_id = data.get("mam_id") or cfg.get("mam", {}).get("mam_id", "")
+        mam_id = payload.mam_id or cfg.get("mam", {}).get("mam_id", "")
         if not mam_id:
             return {
                 "success": False,

--- a/tests/backend/test_api_models.py
+++ b/tests/backend/test_api_models.py
@@ -3,7 +3,7 @@
 from pydantic import ValidationError
 import pytest
 
-from backend.api_models import IndexerTestRequest
+from backend.api_models import IndexerTestRequest, IndexerUpdateRequest
 
 
 @pytest.mark.parametrize(
@@ -60,3 +60,25 @@ def test_admin_password_is_optional_and_defaults_to_empty() -> None:
     model = IndexerTestRequest(host="h", port=9117, api_key="k")
 
     assert model.admin_password == ""
+
+
+def test_update_request_requires_a_usable_label() -> None:
+    """A blank or whitespace-only label is refused before the session lookup."""
+    for label in ("", "   "):
+        with pytest.raises(ValidationError):
+            IndexerUpdateRequest.model_validate({"label": label})
+
+
+def test_update_request_treats_mam_id_as_optional() -> None:
+    """These endpoints fall back to the session's stored mam_id, so absent is valid."""
+    model = IndexerUpdateRequest.model_validate({"label": "seedbox"})
+
+    assert model.label == "seedbox"
+    assert model.mam_id == ""
+
+
+def test_update_request_strips_its_values() -> None:
+    """Whitespace around a label or mam_id is not part of the value."""
+    model = IndexerUpdateRequest.model_validate({"label": " seedbox ", "mam_id": " cookie "})
+
+    assert (model.label, model.mam_id) == ("seedbox", "cookie")


### PR DESCRIPTION
Continues #118. Six indexer update endpoints repeated the same three lines —
read the body, pull `label`, guard `if not label` — and later re-read
`mam_id` from the same dict. They now share `IndexerUpdateRequest`, keeping
the existing "Session label required" message and the 200-with-success-false
contract, for the reasons given in #118.

**One edge case changes, and it is a better answer.** A whitespace-only
label was truthy, so it passed `if not label` and reached the session lookup:

    POST /api/jackett/update {"label": "   "}
      before: {"success": false, "message": "Session '   ' not found"}
      after:  {"success": false, "message": "Session label required"}

Both refuse the request; the new one names the actual problem rather than
reporting a missing session for a label that was never usable. This is the
same truthy-whitespace hole fixed for session save in #119.

`mam_id` stays optional and defaults to `""`, so `payload.mam_id or
cfg.get(...)` preserves the existing fall-back to the session's stored value
for an absent or blank field.

Three more tests, eighteen in the file. Coverage 45.45%.

Validated: `./scripts/lint.sh` clean on all 16 hooks, backend suite passes,
mypy clean, and the endpoints checked end to end against a running app for a
missing, blank, whitespace, unknown-session and valid label.