### PR TITLE
chore(biome): retire three more settings that restate Biome's defaults

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,6 @@
   },
   "linter": {
     "rules": {
-      "preset": "recommended",
       "a11y": "error",
       "correctness": {
         "noUnusedVariables": {
@@ -41,10 +40,8 @@
     }
   },
   "assist": {
-    "enabled": true,
     "actions": {
       "source": {
-        "organizeImports": "on",
         "useSortedAttributes": "on",
         "useSortedProperties": "on"
       }


### PR DESCRIPTION
Three keys in `biome.json` set a value Biome already uses by default, so they state nothing the tool would not do without them. This deletes them and changes no behaviour: `linter.rules.preset: "recommended"`, `assist.enabled: true`, and `assist.actions.source.organizeImports: "on"`.

This is the second round of #94. That PR retired the six keys whose defaults could be established at the time; these three were the ones left over, and they are settled now.

```json
   "linter": {
     "rules": {
-      "preset": "recommended",
       "a11y": "error",
...
   "assist": {
-    "enabled": true,
     "actions": {
       "source": {
-        "organizeImports": "on",
         "useSortedAttributes": "on",
```

## How each was established

Not from the documentation. Biome has no `--print-config`, so each key was measured by a **paired differential**: two configurations identical in every byte except the key under test, run over a fixture tree built to violate one rule per question, with `biome check --reporter=summary` as the observable. Removing the key must change nothing, **and** a negative control setting it to a non-default value must change something. Without that second half, "inert" and "not read at all" look identical.

The fixture carried a `noDoubleEquals` violation (recommended, so it fires if and only if the recommended preset is in force), two imports in the wrong order and a `<div zebra="1" alpha={...} />` for the two assist actions, a CSS property pair out of order for `useSortedProperties`, a `@package`-tagged cross-folder import for `noPrivateImports` (the `project` domain), a `useEffect` missing a dependency for `useExhaustiveDependencies` (the `react` domain), and both a recommended and a non-recommended `a11y` violation. All ten diagnostics fire on the unmodified configuration.

| Key removed | Effect | Negative control | Effect |
| --- | --- | --- | --- |
| `linter.rules.preset` | no change | `"preset": "none"` | drops `noDoubleEquals` |
| `assist.enabled` | no change | `"enabled": false` | drops all three assist diagnostics |
| `organizeImports` | no change | `"organizeImports": "off"` | drops `organizeImports` |

All three deletions applied together also change nothing, and `biome check --write --unsafe` over two copies of the fixture, one per configuration, produces byte-identical trees. The control for *that* comparison is an arm which additionally drops `useSortedAttributes`: it differs, at `sorted.jsx:5`, so the `diff -r` is not a no-op. An equivalent run over an already-clean tree would have proved nothing.

Every measurement was repeated on **2.5.6**, **2.5.7** (the `prek.toml` hook rev, `frontend/package.json` and `biome.json`'s `$schema`) and **2.5.8**. All three agree on every arm.

## The four keys that stay

`linter.domains.project`, `linter.domains.react`, `useSortedAttributes` and `useSortedProperties` were measured the same way and each differs from the default, so none of them is a candidate.

`linter.domains.react` is worth naming, because deleting it would cost **zero** diagnostics on this tree today and would still be wrong. `biome explain useExhaustiveDependencies` reports the domain is "enabled when one of these dependencies are detected: `react@>=16.0.0`", so it is auto-enabled from the nearest ancestor `package.json`. `frontend/package.json` declares react, which makes the key redundant under `frontend/`; the root `package.json` is a script forwarder that declares no dependencies at all, which leaves `scripts/` covered only by the explicit key. With an identical `useEffect`-missing-dependency probe planted in each location, the key present reports two diagnostics and the key absent reports one. Nothing under `scripts/` is React today, which is exactly why measuring the current tree would get this one wrong.

## Verification

- `./scripts/lint.sh` clean, all 16 hooks. The `biome check` hook reports `Checked 41 files` on this branch and `Checked 41 files` on `main`, so the file set is unchanged and only the three lines moved.
- `./scripts/test.sh` clean: backend pytest and Playwright E2E both pass, backend line coverage 48.9% against `fail_under = 40`.
- `npm --prefix frontend run lint` reports `Checked 39 files`, clean, identically before and after — that invocation passes `--config-path=../biome.json`, so it was checked separately from the hook.
- `biome migrate --write --config-path biome.json`, the exact invocation in `scripts/update-dependencies.sh`, reports "no migration needed" against the post-deletion configuration and rewrites nothing, so routine dependency maintenance will not re-add the keys.
- No documentation to update: a fold-insensitive search for `organizeimports`, `usesortedattributes`, `usesortedproperties`, `assist`, `domains` and `preset` across `README.md`, `docs/`, `AGENTS.md`, `prek.toml`, `scripts/` and `frontend/package.json` returns two hits, both the word "Assistant" in unrelated prose. `scripts/sync-biome-prek-hook.mjs` reads `prek.toml` only and never parses `biome.json`, and no test asserts on its contents.
