### PR TITLE
fix(e2e): stop asserting on toasts that expire before the assertion times out

### DIFF
--- a/frontend/e2e/app.spec.js
+++ b/frontend/e2e/app.spec.js
@@ -6,6 +6,12 @@ async function choose(page, label, option) {
   await expect(page.getByRole('listbox')).toBeHidden();
 }
 
+function waitForPost(page, path) {
+  return page.waitForResponse(
+    (response) => response.url().endsWith(path) && response.request().method() === 'POST',
+  );
+}
+
 test.describe
   .serial('MouseTrap browser lifecycle', () => {
     test.beforeEach(async ({ request }) => {
@@ -52,8 +58,9 @@ test.describe
       await choose(page, 'Interval', '10');
       await page.getByRole('textbox', { name: 'MAM ID', exact: true }).fill('e2e-mam-id');
       await page.getByRole('textbox', { name: 'IP Address', exact: true }).fill('192.0.2.10');
+      const saved = waitForPost(page, '/api/session/save');
       await page.getByRole('button', { name: 'SAVE', exact: true }).click();
-      await expect(page.getByText('Session saved successfully.')).toBeVisible();
+      expect((await saved).ok()).toBeTruthy();
 
       await page.reload();
       await expect(page.getByRole('combobox', { name: 'Session', exact: true })).toContainText(
@@ -92,8 +99,9 @@ test.describe
       await page.getByRole('combobox', { name: 'Proxy', exact: true }).click();
       await page.getByRole('option', { name: /local-proxy/ }).click();
       await expect(page.getByRole('listbox')).toBeHidden();
+      const saved = waitForPost(page, '/api/session/save');
       await page.getByRole('button', { name: 'SAVE', exact: true }).click();
-      await expect(page.getByText('Session saved successfully.')).toBeVisible();
+      expect((await saved).ok()).toBeTruthy();
 
       await page.getByRole('button', { name: 'View event log' }).click();
       await expect(page.getByRole('dialog', { name: 'Event Log' })).toContainText(
@@ -121,8 +129,9 @@ test.describe
       await page
         .getByRole('textbox', { name: 'Webhook URL', exact: true })
         .fill('https://example.invalid/mousetrap-e2e');
+      const saved = waitForPost(page, '/api/notify/config');
       await page.getByRole('button', { name: 'Save Settings' }).click();
-      await expect(page.getByText('Settings saved.')).toBeVisible();
+      expect((await saved).ok()).toBeTruthy();
 
       await page.reload();
       await page.getByText('Notifications', { exact: true }).click();
@@ -132,7 +141,7 @@ test.describe
       );
     });
 
-    test('shows a session save failure without persisting it', async ({ page, request }) => {
+    test('does not persist a failed session save', async ({ page, request }) => {
       const seeded = await request.post('/api/session/save', {
         data: {
           check_freq: 10,
@@ -152,8 +161,9 @@ test.describe
       await page.route('**/api/session/save', (route) =>
         route.fulfill({ body: '{"detail":"simulated failure"}', status: 500 }),
       );
+      const rejected = waitForPost(page, '/api/session/save');
       await page.getByRole('button', { name: 'SAVE', exact: true }).click();
-      await expect(page.getByText('Error saving session: Failed to save session')).toBeVisible();
+      expect((await rejected).ok()).toBeFalsy();
 
       const persisted = await request.get('/api/session/FailureCase');
       expect(persisted.ok()).toBeTruthy();


### PR DESCRIPTION
Four assertions in `frontend/e2e/app.spec.js` waited up to 7500ms for a toast the application removes after 2000ms or 3000ms. Each is a race the suite loses whenever the machine is loaded, and it surfaces as `toBeVisible() … element(s) not found`, which points nowhere near the cause. `playwright.config.js:33` sets `expect: { timeout: 7_500 }`; against that, `Session saved successfully.` is cleared at 2000ms by `MouseTrapConfigCard.jsx:211`, `Settings saved.` at 2000ms by `NotificationsCard.jsx:169`, and `Error saving session: Failed to save session` at 3000ms by `MouseTrapConfigCard.jsx:265`'s `autoHideDuration`. Two of the three windows come from a `setTimeout` that beats the surrounding Snackbar, so reading the MUI prop alone under-reports the exposure.

This is a defect rather than tuning: the assertion states a contract the DOM does not offer. It says "wait up to 7.5s for this to appear" about an element guaranteed to be gone by 2s. Raising `expect.timeout` or lowering `autoHideDuration` would keep that shape and only move the odds, so neither is done here.

Each toast assertion is replaced by a wait on the response that produces it, through one new helper:

```js
function waitForPost(page, path) {
  return page.waitForResponse(
    (response) => response.url().endsWith(path) && response.request().method() === 'POST',
  );
}
```

A response is an event, not an element with a lifetime, so there is nothing left to race. This also preserves synchronisation that a bare deletion would have removed: three of the four sites call `page.reload()` immediately afterwards, and the toast assertion was the only thing holding the reload back until the save had actually completed. The durable consequence each test already checked is unchanged, and is what still carries the coverage: the session reappears after reload, the event log records `Session 'Proxied' saved`, the webhook URL survives a reload, and the failed save leaves `mam_ip` at its seeded value.

No application code is touched. `shows a session save failure without persisting it` is renamed to `does not persist a failed session save`, because the toast was the only error surface the component renders and the old title would have described coverage the test no longer has. If the error toast itself is worth covering, that needs a deterministic lifetime driven from a value the test controls, which is a change to three components and better judged separately.

## Verification

The failure was established before the fix rather than inferred. Cutting the three lifetimes to `1`ms in the components made all four sites fail deterministically, each with the same signature as the original intermittent failure:

```
Error: expect(locator).toBeVisible() failed
  - Expect "toBeVisible" with timeout 7500ms
  - waiting for getByText('Session saved successfully.')      app.spec.js:56
  - waiting for getByText('Session saved successfully.')      app.spec.js:96
  - waiting for getByText('Settings saved.')                  app.spec.js:125
  - waiting for getByText('Error saving session: Failed to save session')  app.spec.js:156
```

With those 1ms lifetimes still in place, the fixed spec passes 5/5. The component edits were then reverted; they are not part of this change. A green run alone would have proved nothing here, since a race that usually passes will usually pass after any edit.

`./scripts/lint.sh` is clean (16/16 hooks). `./scripts/test.sh` is clean: 200 backend tests, 5 Playwright tests, backend coverage 48.9% against `fail_under = 40`. Both were run locally, where `retries: process.env.CI ? 2 : 0` gives zero retries, so nothing was hidden by a retry. Frontend coverage is byte-identical to the pre-change baseline (57.6% lines, 41.9% branches), which is expected: the toast still renders, the suite simply no longer asserts on it.

Worth noting for CI: this flakiness cannot appear there. `retries: 2` on CI passes a flaky spec on a retry and reports green, so the local gate is the stricter of the two, and every check on recent PRs was green in the same window a local run failed.

## Files

- `frontend/e2e/app.spec.js` — the only file changed.

No backend, documentation, deployment, or data-compatibility impact. `AGENTS.md`'s Testing Expectations section prefers accessible role and label locators, which this change does not alter; no locator was added, and one `getByText` was removed.
