### PR TITLE
refactor: remove wedge automation, which MAM no longer supports

### DIFF
--- a/backend/api_automation.py
+++ b/backend/api_automation.py
@@ -1,4 +1,4 @@
-"""API endpoints for manual perk purchases (upload credit, wedge, VIP).
+"""API endpoints for manual perk purchases (upload credit, VIP).
 
 This module exposes FastAPI endpoints under `/automation/*` that allow a
 client to trigger manual perk purchases for a configured session. Each
@@ -18,14 +18,13 @@ from backend.config import load_session, session_exists
 from backend.event_log import append_ui_event_log
 from backend.mam_api import get_status
 from backend.notifications_backend import notify_event
-from backend.perk_automation import buy_upload_credit, buy_vip, buy_wedge
+from backend.perk_automation import buy_upload_credit, buy_vip
 from backend.proxy_config import resolve_proxy_from_session_cfg
 from backend.utils_redact import redact_sensitive
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
 # Point costs for the enforce-minimum-points guardrail
-_WEDGE_POINTS_COST = 50_000
 _VIP_POINTS_COST: dict[int, int] = {4: 5_000, 8: 10_000}  # weeks -> points; 90/max is variable
 _UPLOAD_POINTS_PER_GB = 500
 
@@ -156,125 +155,6 @@ async def manual_upload_credit(request: Request) -> dict[str, Any]:
         _logger.warning(
             "[ManualUpload] Purchase: %sGB upload credit for session '%s' FAILED. Error: %s",
             amount,
-            label,
-            error_val,
-        )
-    return {"success": success, **result}
-
-
-@router.post("/automation/wedge")
-async def manual_wedge(request: Request) -> dict[str, Any]:
-    """Trigger a manual wedge purchase for a session.
-
-    Expects a JSON body with the following fields:
-    - label: session label (required)
-    - method: purchase method (optional, defaults to "points")
-
-    The endpoint logs the event, attempts the wedge purchase via the
-    perk_automation module, and tries to notify configured notification
-    backends. Returns a dict with a "success" boolean and details from the
-    purchase attempt.
-
-    Raises:
-        HTTPException: If the required `label` field is missing from the
-            request JSON.
-
-    """
-    data = await request.json()
-    label = data.get("label")
-    method = data.get("method", "points")
-    if not label:
-        raise HTTPException(status_code=400, detail="Session label required.")
-    if not session_exists(label):
-        _logger.warning("[ManualWedge] Session '%s' not found or not configured.", label)
-        return {"success": False, "error": f"Session '{label}' not found."}
-    cfg = load_session(label)
-    mam_id = cfg.get("mam", {}).get("mam_id", "")
-
-    proxy_cfg = resolve_proxy_from_session_cfg(cfg)
-    now = datetime.now(UTC)
-    # --- Enforce minimum points guardrail (prevent spend below minimum) ---
-    # Only applies to points method; cheese method has no point cost
-    enforce_min_pts = cfg.get("perk_automation", {}).get("enforce_min_points_guardrail", False)
-    session_min_points = cfg.get("perk_automation", {}).get("min_points")
-    if enforce_min_pts and session_min_points is not None and method == "points":
-        status = await get_status(mam_id=mam_id, proxy_cfg=proxy_cfg)
-        current_points = status.get("points", 0)
-        if current_points is None:
-            current_points = 0
-        purchase_cost = _WEDGE_POINTS_COST
-        if int(current_points) - purchase_cost < int(session_min_points):
-            guardrail_reason = (
-                f"Purchase would drop below minimum points: "
-                f"{current_points} - {purchase_cost} = {int(current_points) - purchase_cost} "
-                f"< {session_min_points}"
-            )
-            _logger.info("[ManualWedge] BLOCKED for session '%s': %s", label, guardrail_reason)
-            append_ui_event_log(
-                {
-                    "timestamp": now.isoformat(),
-                    "label": label,
-                    "event_type": "manual",
-                    "trigger": "manual",
-                    "purchase_type": "wedge",
-                    "amount": 1,
-                    "details": {"method": method, "points_before": current_points},
-                    "result": "blocked",
-                    "status_message": f"Manual Wedge purchase blocked: {guardrail_reason}",
-                }
-            )
-            return {"success": False, "error": guardrail_reason}
-    result = await buy_wedge(mam_id, method=method, proxy_cfg=proxy_cfg)
-    success = result.get("success", False)
-    status_message = (
-        f"Purchased Wedge ({method})" if success else f"Wedge purchase failed ({method})"
-    )
-    event = {
-        "timestamp": now.isoformat(),
-        "label": label,
-        "event_type": "manual",
-        "trigger": "manual",
-        "purchase_type": "wedge",
-        "amount": 1,
-        "details": {"method": method},
-        "result": "success" if success else "failed",
-        "error": result.get("error") if not success else None,
-        "status_message": status_message,
-    }
-    append_ui_event_log(event)
-    try:
-        if success:
-            await notify_event(
-                event_type="manual_purchase_success",
-                label=label,
-                status="SUCCESS",
-                message=f"Manual Wedge purchase succeeded: {method}",
-                details={"method": method},
-            )
-        else:
-            await notify_event(
-                event_type="manual_purchase_failure",
-                label=label,
-                status="FAILED",
-                message=f"Manual Wedge purchase failed: {method}",
-                details={"method": method, "error": result.get("error")},
-            )
-    except Exception:
-        _logger.debug("[ManualWedge] Manual wedge purchse notification failed.")
-    if success:
-        _logger.info(
-            "[ManualWedge] Purchase: Wedge (%s) for session '%s' succeeded.",
-            method,
-            label,
-        )
-    else:
-        redacted_result = redact_sensitive(result)
-        error_val = (
-            redacted_result.get("error") if isinstance(redacted_result, dict) else redacted_result
-        )
-        _logger.warning(
-            "[ManualWedge] Purchase: Wedge (%s) for session '%s' FAILED. Error: %s",
-            method,
             label,
             error_val,
         )

--- a/backend/app.py
+++ b/backend/app.py
@@ -390,7 +390,7 @@ def api_automation_guardrails() -> dict[str, Any]:
 
     Example:
         {
-            "Gluetun": {"username": "example_user", "autoUpload": true, "autoWedge": false, "autoVIP": false},
+            "Gluetun": {"username": "example_user", "autoUpload": true, "autoVIP": false},
             ...
         }
 
@@ -411,7 +411,6 @@ def api_automation_guardrails() -> dict[str, Any]:
         result[label] = {
             "username": username,
             "autoUpload": perk_auto.get("upload_credit", {}).get("enabled", False),
-            "autoWedge": perk_auto.get("wedge_automation", {}).get("enabled", False),
             "autoVIP": perk_auto.get("vip_automation", {}).get("enabled", False),
         }
     return result
@@ -1861,8 +1860,6 @@ async def api_save_perkautomation(request: Request) -> dict[str, Any]:
                 ts_field = "last_upload_time"
             elif automation_key == "vip_automation":
                 ts_field = "last_vip_time"
-            elif automation_key == "wedge_automation":
-                ts_field = "last_wedge_time"
             if not ts_field:
                 return
             # If disabling, always clear timestamp
@@ -1885,7 +1882,6 @@ async def api_save_perkautomation(request: Request) -> dict[str, Any]:
 
         handle_time_trigger("upload_credit")
         handle_time_trigger("vip_automation")
-        handle_time_trigger("wedge_automation")
 
         cfg["perk_automation"] = new_pa
         save_session(cfg, old_label=label)

--- a/backend/automation.py
+++ b/backend/automation.py
@@ -1,7 +1,7 @@
 """Automation helpers for scheduled MaM perk purchases.
 
 This module contains functions that implement scheduled automation jobs for
-MyAnonamouse (MaM) perk purchases such as upload credit, VIP, and wedge.
+MyAnonamouse (MaM) perk purchases such as upload credit and VIP.
 Each job enumerates saved sessions, evaluates guardrails (session-level and
 automation-level), and attempts purchases via helper functions in
 `backend.perk_automation`. Events and status updates are recorded via
@@ -11,7 +11,6 @@ Functions provided:
 - run_all_automation_jobs: convenience runner that invokes each job.
 - upload_credit_automation_job: automation for upload credit purchases.
 - vip_automation_job: automation for VIP purchases.
-- wedge_automation_job: automation for wedge purchases.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -24,13 +23,12 @@ from backend.config import list_sessions, load_session, save_session
 from backend.event_log import append_ui_event_log
 from backend.mam_api import get_status
 from backend.notifications_backend import notify_event
-from backend.perk_automation import buy_upload_credit, buy_vip, buy_wedge
+from backend.perk_automation import buy_upload_credit, buy_vip
 from backend.proxy_config import resolve_proxy_from_session_cfg
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
 # Point costs for the enforce-minimum-points guardrail
-_WEDGE_POINTS_COST = 50_000
 _VIP_POINTS_COST: dict[int, int] = {4: 5_000, 8: 10_000}  # weeks -> points; 90/max is variable
 _UPLOAD_POINTS_PER_GB = 500
 _shutdown_event = threading.Event()
@@ -79,13 +77,11 @@ def _persist_automation_state(
 async def run_all_automation_jobs() -> None:
     """Run all available automation jobs.
 
-    Convenience function to sequentially run upload credit, wedge, and VIP
-    automation jobs. Intended to be called by a scheduler or from startup
-    code.
+    Convenience function to sequentially run upload credit and VIP automation
+    jobs. Intended to be called by a scheduler or from startup code.
     """
     for automation_job in (
         upload_credit_automation_job,
-        wedge_automation_job,
         vip_automation_job,
     ):
         if automation_shutdown_requested():
@@ -621,224 +617,4 @@ async def vip_automation_job() -> None:
         except Exception as e:
             _logger.error(
                 "[VIPAuto] label=%s trigger=automation result=exception error=%s", label, e
-            )
-
-
-async def wedge_automation_job() -> None:
-    """Evaluate and run wedge automation for all sessions.
-
-    For each configured session this function:
-    - loads session configuration
-    - checks session- and automation-level guardrails (min points, time,
-      point thresholds)
-    - attempts wedge purchases via `buy_wedge` when guardrails are satisfied
-    - logs results and records events via `append_ui_event_log`.
-    """
-
-    session_labels = list_sessions()
-    now = datetime.now(UTC)
-    for label in session_labels:
-        if automation_shutdown_requested():
-            return
-        try:
-            cfg = load_session(label)  # Always reload config
-            mam_id = cfg.get("mam", {}).get("mam_id", "")
-            if not mam_id:
-                continue
-            automation = cfg.get("perk_automation", {}).get("wedge_automation", {})
-            enabled = automation.get("enabled", False)
-            if not enabled:
-                continue
-            trigger_type = automation.get("trigger_type", "points")
-            trigger_days = automation.get("trigger_days", 7)
-            trigger_point_threshold = automation.get("trigger_point_threshold", 50000)
-
-            proxy_cfg = resolve_proxy_from_session_cfg(cfg)  # Always resolve proxy
-            status = await get_status(mam_id=mam_id, proxy_cfg=proxy_cfg)
-            points = status.get("points", 0)
-            if points is None:
-                points = 0
-            # --- Session-level minimum points guardrail (first, before any automation-level checks) ---
-            session_min_points = cfg.get("perk_automation", {}).get("min_points")
-            _logger.debug(
-                "[AutoWedge][DEBUG] Session '%s': points=%s, session_min_points=%s",
-                label,
-                points,
-                session_min_points,
-            )
-            if session_min_points is not None and int(points) < int(session_min_points):
-                guardrail_reason = f"Below session minimum points: {points} < {session_min_points}"
-                log_msg = "[AutoWedge] SKIP: Automated Wedge purchase for session '%s' skipped: %s"
-                _logger.info(log_msg, label, guardrail_reason)
-                append_ui_event_log(
-                    {
-                        "timestamp": now.isoformat(),
-                        "label": label,
-                        "event_type": "automation",
-                        "trigger": "automation",
-                        "purchase_type": "wedge",
-                        "amount": 1,
-                        "details": {"points_before": points},
-                        "result": "skipped",
-                        "status_message": f"Automated Wedge purchase skipped: {guardrail_reason}",
-                    }
-                )
-                # Do not check any automation-level guardrails if session minimum is not met
-                continue
-            # --- Enforce minimum points guardrail (prevent spend below minimum) ---
-            enforce_min_points_guardrail = cfg.get("perk_automation", {}).get(
-                "enforce_min_points_guardrail", False
-            )
-            if enforce_min_points_guardrail and session_min_points is not None:
-                purchase_cost = _WEDGE_POINTS_COST  # Automation always uses points method
-                if int(points) - purchase_cost < int(session_min_points):
-                    guardrail_reason = (
-                        f"Purchase would drop below minimum points: "
-                        f"{points} - {purchase_cost} = {int(points) - purchase_cost} "
-                        f"< {session_min_points}"
-                    )
-                    log_msg = (
-                        "[AutoWedge] SKIP: Automated Wedge purchase for session '%s' skipped: %s"
-                    )
-                    _logger.info(log_msg, label, guardrail_reason)
-                    append_ui_event_log(
-                        {
-                            "timestamp": now.isoformat(),
-                            "label": label,
-                            "event_type": "automation",
-                            "trigger": "automation",
-                            "purchase_type": "wedge",
-                            "amount": 1,
-                            "details": {"points_before": points},
-                            "result": "skipped",
-                            "status_message": f"Automated Wedge purchase skipped: {guardrail_reason}",
-                        }
-                    )
-                    continue
-            # --- Time-based trigger enforcement ---
-            last_wedge_time = (
-                cfg.get("perk_automation", {}).get("wedge_automation", {}).get("last_wedge_time")
-            )
-            last_purchase = None
-            if last_wedge_time:
-                try:
-                    last_purchase = datetime.fromisoformat(last_wedge_time)
-                except Exception:
-                    last_purchase = None
-            now_dt = now
-            time_trigger_ok = True
-            if trigger_type in ("time", "both"):
-                if last_purchase:
-                    next_allowed = last_purchase + timedelta(days=int(trigger_days))
-                    if now_dt < next_allowed:
-                        time_trigger_ok = False
-                else:
-                    # No last purchase: skip until a successful purchase sets the timestamp
-                    time_trigger_ok = False
-            if not time_trigger_ok:
-                if last_purchase:
-                    next_allowed = last_purchase + timedelta(days=int(trigger_days))
-                    next_allowed_str = next_allowed.isoformat()
-                    guardrail_reason = (
-                        f"Time-based trigger not satisfied: next allowed after {next_allowed_str}"
-                    )
-                else:
-                    guardrail_reason = (
-                        "No previous purchase timestamp found. "
-                        "Please toggle and save the automation to start the timer. "
-                        "(Time-based trigger not satisfied.)"
-                    )
-                log_msg = "[AutoWedge] SKIP: Automated Wedge purchase for session '%s' skipped: %s"
-                _logger.info(log_msg, label, guardrail_reason)
-                append_ui_event_log(
-                    {
-                        "timestamp": now.isoformat(),
-                        "label": label,
-                        "event_type": "automation",
-                        "trigger": "automation",
-                        "purchase_type": "wedge",
-                        "amount": 1,
-                        "details": {"points_before": points},
-                        "result": "skipped",
-                        "status_message": f"Automated Wedge purchase skipped: {guardrail_reason}",
-                    }
-                )
-                continue
-            # --- Automation-level point threshold guardrail ---
-            if trigger_type in ("points", "both") and int(points) < int(trigger_point_threshold):
-                guardrail_reason = (
-                    f"Below automation point threshold: {points} < {trigger_point_threshold}"
-                )
-                log_msg = "[AutoWedge] SKIP: Automated Wedge purchase for session '%s' skipped: %s"
-                _logger.info(log_msg, label, guardrail_reason)
-                append_ui_event_log(
-                    {
-                        "timestamp": now.isoformat(),
-                        "label": label,
-                        "event_type": "automation",
-                        "trigger": "automation",
-                        "purchase_type": "wedge",
-                        "amount": 1,
-                        "details": {"points_before": points},
-                        "result": "skipped",
-                        "status_message": f"Automated Wedge purchase skipped: {guardrail_reason}",
-                    }
-                )
-                continue
-            # All guardrails passed, attempt purchase
-            result = await buy_wedge(mam_id, proxy_cfg=proxy_cfg)
-            success = result.get("success", False) if result else False
-            status_message = (
-                "Automated purchase: Wedge (points)"
-                if success
-                else "Automated Wedge purchase failed (points)"
-            )
-            event = {
-                "timestamp": now.isoformat(),
-                "label": label,
-                "event_type": "automation",
-                "trigger": "automation",
-                "purchase_type": "wedge",
-                "amount": 1,
-                "details": {"points_before": points},
-                "result": "success" if success else "failed",
-                "error": None
-                if success
-                else (result.get("error") or result.get("response") or "Unknown error"),
-                "status_message": status_message,
-            }
-
-            if success:
-                # Update last purchase timestamp in new field
-                _persist_automation_state(
-                    label, "wedge_automation", {"last_wedge_time": now_dt.isoformat()}
-                )
-                _logger.info(
-                    "[WedgeAuto] Automated purchase: Wedge (points) for session '%s' succeeded.",
-                    label,
-                )
-                await notify_event(
-                    event_type="automation_success",
-                    label=label,
-                    status="SUCCESS",
-                    message="Automated Wedge purchase succeeded: 1",
-                    details={"amount": 1, "points_before": points},
-                )
-            else:
-                _logger.warning(
-                    "[WedgeAuto] Automated purchase: Wedge (points) for session '%s' FAILED. Error: %s",
-                    label,
-                    event["error"],
-                )
-                await notify_event(
-                    event_type="automation_failure",
-                    label=label,
-                    status="FAILED",
-                    message="Automated Wedge purchase failed: 1",
-                    details={"amount": 1, "points_before": points, "error": event["error"]},
-                )
-            append_ui_event_log(event)
-        except Exception as e:
-            _logger.error(
-                "[WedgeAuto] label=%s trigger=automation result=exception error=%s", label, e
             )

--- a/backend/config.py
+++ b/backend/config.py
@@ -110,21 +110,6 @@ def load_session(label: str) -> dict[str, Any]:
     for k, v in upload_defaults.items():
         upload_auto.setdefault(k, v)
 
-    # Wedge Automation defaults
-    wedge_defaults = {
-        "enabled": False,
-        "trigger_days": 7,
-        "trigger_point_threshold": 50000,
-        "trigger_type": "time",
-    }
-    wedge_auto = _ensure_mapping(
-        perk_auto,
-        "wedge_automation",
-        "perk_automation.wedge_automation",
-    )
-    for k, v in wedge_defaults.items():
-        wedge_auto.setdefault(k, v)
-
     # VIP Automation defaults
     vip_defaults = {
         "enabled": False,

--- a/backend/perk_automation.py
+++ b/backend/perk_automation.py
@@ -1,4 +1,4 @@
-"""Utilities to automate purchases of perks (upload credit, VIP, wedges) via the MaM API.
+"""Utilities to automate purchases of perks (upload credit, VIP) via the MaM API.
 
 Functions handle proxy configuration, make HTTP requests to the MaM JSON API,
 and return structured result dictionaries.
@@ -186,85 +186,6 @@ async def buy_vip(
                 return {"success": True, "response": data}
     except Exception as e:
         _logger.error("[buy_vip] Exception: %s", e)
-        return {"success": False, "error": str(e)}
-    else:
-        return {"success": False, "response": data}
-
-
-async def buy_wedge(
-    mam_id: str, method: str = "points", proxy_cfg: dict[str, Any] | None = None
-) -> dict[str, Any]:
-    """Purchase a wedge using points or cheese via the MaM API.
-
-    method: "points" or "cheese"
-    proxy_cfg: optional proxy config dict
-    """
-    if method not in ("points", "cheese"):
-        return {"success": False, "error": f"Unsupported wedge purchase method: {method}"}
-
-    timestamp = int(time.time() * 1000)
-    url = f"https://www.myanonamouse.net/json/bonusBuy.php/?spendtype=wedges&source={method}&_={timestamp}"
-    cookies = {"mam_id": mam_id}
-    proxies = None
-    if proxy_cfg is not None:
-        proxies = build_proxy_dict(proxy_cfg)
-        if proxies:
-            proxy_label = proxy_cfg.get("label") if proxy_cfg else None
-            proxy_url_log = {
-                k: v.replace(proxy_cfg.get("password", ""), "***")
-                if proxy_cfg and proxy_cfg.get("password")
-                else v
-                for k, v in proxies.items()
-            }
-            _logger.debug(
-                "[buy_wedge] Using proxy label: %s, proxies: %s", proxy_label, proxy_url_log
-            )
-    try:
-        _logger.debug("[buy_wedge] Making request to: %s", url)
-        proxy_url = None
-        proxy_auth = None
-        if proxy_cfg is not None:
-            proxies = build_proxy_dict(proxy_cfg)
-            proxy_url = (
-                proxies.get("https")
-                if proxies and proxies.get("https")
-                else (proxies.get("http") if proxies else None)
-            )
-            username = proxy_cfg.get("username") if proxy_cfg else None
-            password = proxy_cfg.get("password") if proxy_cfg else None
-            if username and password:
-                proxy_auth = aiohttp.BasicAuth(username, password)
-
-        timeout = aiohttp.ClientTimeout(total=10)
-        async with (
-            aiohttp.ClientSession(timeout=timeout) as session,
-            session.get(
-                url, cookies=cookies, proxy=proxy_url, proxy_auth=proxy_auth, headers=_BONUS_HEADERS
-            ) as resp,
-        ):
-            _logger.debug("[buy_wedge] Response: status=%s", resp.status)
-            if resp.status != 200:
-                text = await resp.text()
-                return {
-                    "success": False,
-                    "error": f"HTTP {resp.status}",
-                    "raw_response": text[:500],
-                    "status_code": resp.status,
-                }
-            try:
-                data = await resp.json()
-            except Exception as json_e:
-                text = await resp.text()
-                return {
-                    "success": False,
-                    "error": f"Non-JSON response: {json_e}",
-                    "raw_response": text[:500],
-                    "status_code": resp.status,
-                }
-            if data.get("success") or data.get("Success"):
-                return {"success": True, "response": data}
-    except Exception as e:
-        _logger.error("[buy_wedge] Exception: %s", e)
         return {"success": False, "error": str(e)}
     else:
         return {"success": False, "response": data}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -66,12 +66,10 @@ export default function App() {
     setAutobrr,
   } = useSession();
   // State for automation and perks
-  const [autoWedge, setAutoWedge] = React.useState(false);
   const [autoVIP, setAutoVIP] = React.useState(false);
   const [autoUpload, setAutoUpload] = React.useState(false);
   const [uploadAmount, setUploadAmount] = React.useState(0);
   const [vipWeeks, setVipWeeks] = React.useState(0);
-  const [wedgeMethod, setWedgeMethod] = React.useState('');
   const [forceExpandConfig, setForceExpandConfig] = React.useState(false);
   const [proxies, setProxies] = React.useState({});
   const [sessions, setSessions] = React.useState([]);
@@ -367,7 +365,6 @@ export default function App() {
             <PerkAutomationCard
               autoUpload={autoUpload}
               autoVIP={autoVIP}
-              autoWedge={autoWedge}
               onActionComplete={() => {
                 if (statusCardRef.current?.fetchStatus) {
                   statusCardRef.current.fetchStatus();
@@ -375,13 +372,10 @@ export default function App() {
               }}
               setAutoUpload={setAutoUpload}
               setAutoVIP={setAutoVIP}
-              setAutoWedge={setAutoWedge}
               setUploadAmount={setUploadAmount}
               setVipWeeks={setVipWeeks}
-              setWedgeMethod={setWedgeMethod}
               uploadAmount={uploadAmount}
               vipWeeks={vipWeeks}
-              wedgeMethod={wedgeMethod}
             />
           )}
           {/* 4. Notifications */}

--- a/frontend/src/components/AutomationSection.jsx
+++ b/frontend/src/components/AutomationSection.jsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material';
 
 /**
- * Generic automation section for PerkAutomationCard (Wedge, VIP, Upload, etc)
+ * Generic automation section for PerkAutomationCard (VIP, Upload, etc)
  * Props:
  * - title: string
  * - enabled: boolean

--- a/frontend/src/components/AutomationStatusRow.jsx
+++ b/frontend/src/components/AutomationStatusRow.jsx
@@ -16,7 +16,6 @@ export default function AutomationStatusRow({ autoVIP, autoUpload }) {
         <Typography sx={{ fontWeight: 600, mr: 1 }} variant="subtitle1">
           Automation:
         </Typography>
-        {/* Wedge status hidden - MAM removed wedge purchase from their API */}
         <Box sx={{ alignItems: 'center', display: 'flex', gap: 0.5, ml: 2 }}>
           <Typography sx={{ fontWeight: 500 }} variant="body2">
             VIP Time:

--- a/frontend/src/components/PerkAutomationCard.jsx
+++ b/frontend/src/components/PerkAutomationCard.jsx
@@ -24,34 +24,21 @@ import FeedbackSnackbar from './FeedbackSnackbar';
 
 /**
  * @typedef {Object} PerkAutomationCardProps
- * @property {function} setAutoWedge
  * @property {function} setAutoVIP
  * @property {function} setAutoUpload
  * @property {function} setUploadAmount
  * @property {function} setVipWeeks
- * @property {function} setWedgeMethod
- * @property {boolean} [autoWedge]
  * @property {boolean} [autoVIP]
  * @property {boolean} [autoUpload]
  * @property {function} [onActionComplete]
  * @property {number} [uploadAmount]
  * @property {number} [vipWeeks]
- * @property {string} [wedgeMethod]
  */
 /** @param {PerkAutomationCardProps} props */
 export default function PerkAutomationCard(props) {
-  const {
-    autoWedge,
-    setAutoWedge,
-    autoVIP,
-    setAutoVIP,
-    autoUpload,
-    setAutoUpload,
-    onActionComplete = () => {},
-  } = props;
+  const { autoVIP, setAutoVIP, autoUpload, setAutoUpload, onActionComplete = () => {} } = props;
   const { sessionLabel, points, setPoints } = useSession();
   // Local state for automation toggles, initialized from props if provided
-  const [, setAutoWedgeLocal] = useState(autoWedge ?? false);
   const [, setAutoVIPLocal] = useState(autoVIP ?? false);
   const [, setAutoUploadLocal] = useState(autoUpload ?? false);
   const [minPoints, setMinPoints] = useState(0);
@@ -60,13 +47,6 @@ export default function PerkAutomationCard(props) {
   // Ensure prop setters update both local and parent state. Memoize so
   // they can safely be used in effect dependency arrays without
   // triggering Biome/react-hooks warnings.
-  const setAutoWedgeCombined = useCallback(
-    (val) => {
-      setAutoWedgeLocal(val);
-      if (typeof setAutoWedge === 'function') setAutoWedge(val);
-    },
-    [setAutoWedge],
-  );
 
   const setAutoVIPCombined = useCallback(
     (val) => {
@@ -93,10 +73,8 @@ export default function PerkAutomationCard(props) {
   const [guardrails, setGuardrails] = useState(null);
   const [currentUsername, setCurrentUsername] = useState(null);
   const [uploadDisabled, setUploadDisabled] = useState(false);
-  const [_wedgeDisabled, setWedgeDisabled] = useState(false);
   const [vipDisabled, setVIPDisabled] = useState(false);
   const [uploadGuardMsg, setUploadGuardMsg] = useState('');
-  const [_wedgeGuardMsg, setWedgeGuardMsg] = useState('');
   const [vipGuardMsg, setVIPGuardMsg] = useState('');
   // Upload automation options state
   const [triggerType, setTriggerType] = useState('time');
@@ -105,15 +83,9 @@ export default function PerkAutomationCard(props) {
   const [expanded, setExpanded] = useState(false);
   const [uploadAmount, setUploadAmount] = useState(50);
   const [vipWeeks, setVipWeeks] = useState(4);
-  const [wedgeMethod, _setWedgeMethod] = useState('points');
-  const [wedgeTriggerType, setWedgeTriggerType] = useState('time');
-  const [wedgeTriggerDays, setWedgeTriggerDays] = useState(7);
   const [confirmVIPOpen, setConfirmVIPOpen] = useState(false);
   const [confirmUploadOpen, setConfirmUploadOpen] = useState(false);
-  const [confirmWedgeOpen, setConfirmWedgeOpen] = useState(false);
 
-  // Wedge automation options state
-  const [wedgeTriggerPointThreshold, setWedgeTriggerPointThreshold] = useState(50000);
   const [vipTriggerType, setVipTriggerType] = useState('time');
   const [vipTriggerDays, setVipTriggerDays] = useState(7);
   const [vipTriggerPointThreshold, setVipTriggerPointThreshold] = useState(50000);
@@ -137,12 +109,6 @@ export default function PerkAutomationCard(props) {
         setTriggerType(upload.trigger_type ?? 'time');
         setTriggerDays(upload.trigger_days ?? 7);
         setTriggerPointThreshold(upload.trigger_point_threshold ?? 50000);
-        // --- Wedge Automation fields ---
-        const wedge = pa.wedge_automation || {};
-        setAutoWedgeCombined(wedge.enabled ?? pa.autoWedge ?? false);
-        setWedgeTriggerType(wedge.trigger_type ?? 'time');
-        setWedgeTriggerDays(wedge.trigger_days ?? 7);
-        setWedgeTriggerPointThreshold(wedge.trigger_point_threshold ?? 50000);
         // --- VIP Automation fields ---
         const vip = pa.vip_automation || {};
         setAutoVIPCombined(vip.enabled ?? pa.autoVIP ?? false);
@@ -160,16 +126,14 @@ export default function PerkAutomationCard(props) {
     fetch('/api/automation/guardrails')
       .then((res) => res.json())
       .then((data) => setGuardrails(data));
-  }, [sessionLabel, setAutoUploadCombined, setAutoVIPCombined, setAutoWedgeCombined, setPoints]);
+  }, [sessionLabel, setAutoUploadCombined, setAutoVIPCombined, setPoints]);
 
   // Guardrail logic: check if another session with same username has automation enabled
   useEffect(() => {
     if (!guardrails || !currentUsername || !sessionLabel) return;
     let upload = false,
-      wedge = false,
       vip = false;
     let uploadMsg = '',
-      wedgeMsg = '',
       vipMsg = '';
     for (const [label, info] of Object.entries(guardrails)) {
       if (label === sessionLabel) continue;
@@ -178,10 +142,6 @@ export default function PerkAutomationCard(props) {
           upload = true;
           uploadMsg = `Upload automation is enabled in session '${label}' for this username.`;
         }
-        if (info.autoWedge) {
-          wedge = true;
-          wedgeMsg = `Wedge automation is enabled in session '${label}' for this username.`;
-        }
         if (info.autoVIP) {
           vip = true;
           vipMsg = `VIP automation is enabled in session '${label}' for this username.`;
@@ -189,39 +149,12 @@ export default function PerkAutomationCard(props) {
       }
     }
     setUploadDisabled(upload);
-    setWedgeDisabled(wedge);
     setVIPDisabled(vip);
     setUploadGuardMsg(uploadMsg);
-    setWedgeGuardMsg(wedgeMsg);
     setVIPGuardMsg(vipMsg);
   }, [guardrails, currentUsername, sessionLabel]);
 
   // API call helpers
-  const _triggerWedge = async () => {
-    try {
-      const res = await fetch('/api/automation/wedge', { method: 'POST' });
-      const data = await res.json();
-      if (data.success) {
-        setSnackbar({
-          message: 'Wedge automation triggered!',
-          open: true,
-          severity: 'success',
-        });
-        onActionComplete();
-      } else
-        setSnackbar({
-          message: stringifyMessage(data.error || 'Wedge automation failed'),
-          open: true,
-          severity: 'error',
-        });
-    } catch (_e) {
-      setSnackbar({
-        message: 'Wedge automation failed',
-        open: true,
-        severity: 'error',
-      });
-    }
-  };
   const _triggerVIP = async () => {
     try {
       const res = await fetch('/api/automation/vip', { method: 'POST' });
@@ -272,36 +205,6 @@ export default function PerkAutomationCard(props) {
     } catch (_e) {
       setSnackbar({
         message: 'Upload automation failed',
-        open: true,
-        severity: 'error',
-      });
-    }
-  };
-  // Manual wedge purchase handler
-  const triggerManualWedge = async (method) => {
-    try {
-      const res = await fetch('/api/automation/wedge', {
-        body: JSON.stringify({ label: sessionLabel, method }), // Always include label
-        headers: { 'Content-Type': 'application/json' },
-        method: 'POST',
-      });
-      const data = await res.json();
-      if (data.success) {
-        setSnackbar({
-          message: `Wedge purchased with ${method}!`,
-          open: true,
-          severity: 'success',
-        });
-        onActionComplete();
-      } else
-        setSnackbar({
-          message: stringifyMessage(data.error || `Wedge purchase with ${method} failed`),
-          open: true,
-          severity: 'error',
-        });
-    } catch (_e) {
-      setSnackbar({
-        message: `Wedge purchase with ${method} failed`,
         open: true,
         severity: 'error',
       });
@@ -380,14 +283,12 @@ export default function PerkAutomationCard(props) {
       return;
     }
     // Load previous automation config if available (to preserve timestamps)
-    let prevWedgeTime = null,
-      prevVIPTime = null,
+    let prevVIPTime = null,
       prevUploadTime = null;
     try {
       const res = await fetch(`/api/session/${encodeURIComponent(sessionLabel)}`);
       if (res.ok) {
         const cfg = await res.json();
-        prevWedgeTime = cfg?.perk_automation?.wedge_automation?.last_wedge_time ?? null;
         prevVIPTime = cfg?.perk_automation?.vip_automation?.last_vip_time ?? null;
         prevUploadTime = cfg?.perk_automation?.upload_credit?.last_upload_time ?? null;
       }
@@ -405,14 +306,12 @@ export default function PerkAutomationCard(props) {
       }
     }
 
-    const newWedgeTime = getNewTimestamp(autoWedge, wedgeTriggerType, prevWedgeTime);
     const newVIPTime = getNewTimestamp(autoVIP, vipTriggerType, prevVIPTime);
     const newUploadTime = getNewTimestamp(autoUpload, triggerType, prevUploadTime);
 
     const perk_automation = {
       autoUpload,
       autoVIP,
-      autoWedge,
       enforce_min_points_guardrail: enforceMinPoints,
       min_points: Number(minPoints),
       upload_credit: {
@@ -430,13 +329,6 @@ export default function PerkAutomationCard(props) {
         trigger_point_threshold: Number(vipTriggerPointThreshold),
         trigger_type: vipTriggerType,
         weeks: Number(vipWeeks),
-      },
-      wedge_automation: {
-        enabled: autoWedge,
-        last_wedge_time: newWedgeTime,
-        trigger_days: Number(wedgeTriggerDays),
-        trigger_point_threshold: Number(wedgeTriggerPointThreshold),
-        trigger_type: wedgeTriggerType,
       },
     };
     const res = await fetch('/api/session/perkautomation/save', {
@@ -518,44 +410,6 @@ export default function PerkAutomationCard(props) {
               />
             </Tooltip>
           </Box>
-          {/* Wedge Section hidden - MAM removed wedge purchase from their API */}
-          {/* <AutomationSection
-            confirmButton={
-              <Tooltip title="This will instantly purchase a wedge using the selected method.">
-                <Box sx={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
-                  <Button
-                    onClick={() => setConfirmWedgeOpen(true)}
-                    sx={{ minWidth: 180 }}
-                    variant="contained"
-                  >
-                    Purchase Wedge
-                  </Button>
-                </Box>
-              </Tooltip>
-            }
-            enabled={autoWedge}
-            onSelectChange={(e) => setWedgeMethod(e.target.value)}
-            onToggle={(e) => setAutoWedgeCombined(e.target.checked)}
-            onTriggerDaysChange={(e) => setWedgeTriggerDays(parseInt(e.target.value, 10) || 0)}
-            onTriggerPointThresholdChange={(e) =>
-              setWedgeTriggerPointThreshold(parseInt(e.target.value, 10) || 0)
-            }
-            onTriggerTypeChange={(e) => setWedgeTriggerType(e.target.value)}
-            selectLabel="Method"
-            selectOptions={[
-              { label: 'Points (50,000)', value: 'points' },
-              { label: 'Cheese (5)', value: 'cheese' },
-            ]}
-            selectValue={wedgeMethod}
-            title="Wedge Purchase"
-            toggleDisabled={wedgeDisabled}
-            toggleLabel="Enable Wedge Automation"
-            tooltip={wedgeDisabled ? wedgeGuardMsg : ''}
-            triggerDays={wedgeTriggerDays}
-            triggerPointThreshold={wedgeTriggerPointThreshold}
-            triggerTypeValue={wedgeTriggerType}
-          />
-          <Divider sx={{ mb: 3 }} /> */}
 
           {/* VIP Section (modularized) */}
           <AutomationSection
@@ -661,13 +515,6 @@ export default function PerkAutomationCard(props) {
           />
 
           {/* Confirmation Dialogs (modularized) */}
-          <ConfirmDialog
-            message={`Are you sure you want to instantly purchase a wedge using ${wedgeMethod === 'points' ? 'Points (50,000)' : 'Cheese (5)'}?`}
-            onClose={() => setConfirmWedgeOpen(false)}
-            onConfirm={() => triggerManualWedge(wedgeMethod)}
-            open={confirmWedgeOpen}
-            title="Confirm Wedge Purchase"
-          />
           <ConfirmDialog
             message={`Are you sure you want to instantly purchase VIP for ${vipWeeks === 90 ? 'up to 90 days (Max me out!)' : `${vipWeeks} weeks`}?`}
             onClose={() => setConfirmVIPOpen(false)}

--- a/tests/backend/test_automation_shutdown.py
+++ b/tests/backend/test_automation_shutdown.py
@@ -82,9 +82,7 @@ def test_shutdown_finishes_current_purchase_and_skips_later_work(
     monkeypatch.setattr(automation, "notify_event", AsyncMock())
     monkeypatch.setattr(automation, "append_ui_event_log", Mock())
     monkeypatch.setattr(automation, "datetime", FixedDateTime)
-    wedge_job = AsyncMock()
     vip_job = AsyncMock()
-    monkeypatch.setattr(automation, "wedge_automation_job", wedge_job)
     monkeypatch.setattr(automation, "vip_automation_job", vip_job)
     automation.reset_automation_shutdown()
 
@@ -101,5 +99,4 @@ def test_shutdown_finishes_current_purchase_and_skips_later_work(
 
     assert not worker.is_alive()
     assert saved_labels == ["first"]
-    wedge_job.assert_not_awaited()
     vip_job.assert_not_awaited()

--- a/tests/backend/test_config.py
+++ b/tests/backend/test_config.py
@@ -37,7 +37,6 @@ def test_invalid_session_yaml_raises(config_dir: Path, contents: str) -> None:
     [
         ("perk_automation: []\n", "perk_automation"),
         ("perk_automation:\n  upload_credit: []\n", "perk_automation.upload_credit"),
-        ("perk_automation:\n  wedge_automation: []\n", "perk_automation.wedge_automation"),
         ("perk_automation:\n  vip_automation: []\n", "perk_automation.vip_automation"),
         ("mam: []\n", "mam"),
         ("prowlarr: []\n", "prowlarr"),

--- a/tests/backend/test_perk_automation.py
+++ b/tests/backend/test_perk_automation.py
@@ -113,16 +113,14 @@ async def _buy_one_of_each() -> None:
     """Run every purchase the module offers, one call each."""
     await perk_automation.buy_upload_credit(1, mam_id=PLACEHOLDER_MAM_ID)
     await perk_automation.buy_vip(PLACEHOLDER_MAM_ID)
-    await perk_automation.buy_wedge(PLACEHOLDER_MAM_ID)
 
 
 async def test_every_purchase_sends_identical_headers(bonus_buy_session: _StubSession) -> None:
-    """Present one identity across the upload credit, VIP and wedge purchases."""
+    """Present one identity across the upload credit and VIP purchases."""
     await _buy_one_of_each()
 
-    upload_credit, vip, wedge = bonus_buy_session.headers_sent
+    upload_credit, vip = bonus_buy_session.headers_sent
     assert upload_credit == vip
-    assert vip == wedge
 
 
 async def test_every_purchase_sends_all_four_header_fields(


### PR DESCRIPTION
MAM withdrew wedge purchasing, which is why the claim was dropped from
README.md in #79. The code stayed: `wedge_automation_job` was still in the
scheduled job list at `automation.py:88` and still called `buy_wedge`, so a
timer job has been firing at a dead endpoint ever since.

Removed across the stack:

- `automation.py` — the scheduled job and its entry in `run_all_automation_jobs`.
- `perk_automation.py` — `buy_wedge`, which POSTed `bonusBuy.php?spendtype=wedges`.
- `api_automation.py` — the `POST /api/automation/wedge` endpoint and
  `_WEDGE_POINTS_COST`. No route matching "wedge" is registered any more;
  a POST to that path now falls through to the SPA catch-all as a 405.
- `app.py` — `autoWedge` in the guardrails payload, and the
  `wedge_automation` arm of the automation timestamp handling.
- `config.py` — the `wedge_automation` defaults. New sessions now get only
  `upload_credit` and `vip_automation`.
- The frontend state, handlers and confirm dialog. The section itself was
  already commented out and the status row already hid it, so nothing
  user-visible disappears that was still on screen.

Net 608 lines.

**Existing user data is left alone.** A session file that already carries
`perk_automation.wedge_automation` keeps them; they are simply never read
again, and nothing rewrites or migrates the file. No configuration change is
required of anyone.

`config.py`'s `"auto_purchase": {"wedge": ..., "vip": ..., "upload": ...}`
default is deliberately untouched. That whole key is written and never read
by anything, so it is separately dead and removing it belongs to its own
change rather than being folded in here.

Four tests needed updating rather than deleting: the two header tests from
#96 now compare two purchase paths instead of three, the config test loses a
parametrised case for a mapping that no longer exists, and the shutdown test
loses the wedge job assertion.

Validated: `./scripts/lint.sh` clean on all 16 hooks including tsc and
biome, backend suite passes, pyright clean, production bundle builds.