### PR TITLE
refactor(automation): share the time-trigger evaluation between both jobs

### DIFF
--- a/backend/automation.py
+++ b/backend/automation.py
@@ -74,6 +74,59 @@ def _persist_automation_state(
 
 
 # --- Automation Scheduler ---
+def _evaluate_time_trigger(
+    last_purchase_iso: str | None,
+    trigger_type: str,
+    trigger_days: Any,
+    now: datetime,
+) -> tuple[bool, str]:
+    """Decide whether a time-based automation trigger is satisfied.
+
+    Shared by the upload-credit and VIP jobs, which carried identical copies of
+    this arithmetic. A trigger type that does not include time is always
+    satisfied here; the caller applies its own points guardrail separately.
+
+    A session with no recorded purchase is deliberately held back rather than
+    treated as due: the interval is measured from the last successful purchase,
+    so the timer only starts once one has been recorded. An unparseable
+    timestamp is treated the same way as no timestamp at all.
+
+    Args:
+        last_purchase_iso: Stored ISO timestamp of the last purchase, if any.
+        trigger_type: Configured trigger type, e.g. "time", "points" or "both".
+        trigger_days: Configured interval in days, as stored in YAML.
+        now: Current time, passed in so callers share one clock.
+
+    Returns:
+        ``(satisfied, reason)``. ``reason`` is empty when satisfied, and
+        otherwise carries the user-facing explanation for the skip.
+
+    """
+    last_purchase = None
+    if last_purchase_iso:
+        try:
+            last_purchase = datetime.fromisoformat(last_purchase_iso)
+        except Exception:
+            last_purchase = None
+
+    if trigger_type not in ("time", "both"):
+        return True, ""
+
+    if last_purchase:
+        next_allowed = last_purchase + timedelta(days=int(trigger_days))
+        if now >= next_allowed:
+            return True, ""
+        return False, (
+            f"Time-based trigger not satisfied: next allowed after {next_allowed.isoformat()}"
+        )
+
+    return False, (
+        "No previous purchase timestamp found. "
+        "Please toggle and save the automation to start the timer. "
+        "(Time-based trigger not satisfied.)"
+    )
+
+
 async def run_all_automation_jobs() -> None:
     """Run all available automation jobs.
 
@@ -190,35 +243,10 @@ async def upload_credit_automation_job() -> None:
             last_upload_time = (
                 cfg.get("perk_automation", {}).get("upload_credit", {}).get("last_upload_time")
             )
-            last_purchase = None
-            if last_upload_time:
-                try:
-                    last_purchase = datetime.fromisoformat(last_upload_time)
-                except Exception:
-                    last_purchase = None
-            now_dt = now
-            time_trigger_ok = True
-            if trigger_type in ("time", "both"):
-                if last_purchase:
-                    next_allowed = last_purchase + timedelta(days=int(trigger_days))
-                    if now_dt < next_allowed:
-                        time_trigger_ok = False
-                else:
-                    # No last purchase: skip until a successful purchase sets the timestamp
-                    time_trigger_ok = False
+            time_trigger_ok, guardrail_reason = _evaluate_time_trigger(
+                last_upload_time, trigger_type, trigger_days, now
+            )
             if not time_trigger_ok:
-                if last_purchase:
-                    next_allowed = last_purchase + timedelta(days=int(trigger_days))
-                    next_allowed_str = next_allowed.isoformat()
-                    guardrail_reason = (
-                        f"Time-based trigger not satisfied: next allowed after {next_allowed_str}"
-                    )
-                else:
-                    guardrail_reason = (
-                        "No previous purchase timestamp found. "
-                        "Please toggle and save the automation to start the timer. "
-                        "(Time-based trigger not satisfied.)"
-                    )
                 log_msg = "[AutoUpload] SKIP: Automated Upload Credit purchase for session '%s' skipped: %s"
                 _logger.info(log_msg, label, guardrail_reason)
                 append_ui_event_log(
@@ -287,7 +315,7 @@ async def upload_credit_automation_job() -> None:
                 )
                 # Update last purchase timestamp in new field
                 _persist_automation_state(
-                    label, "upload_credit", {"last_upload_time": now_dt.isoformat()}
+                    label, "upload_credit", {"last_upload_time": now.isoformat()}
                 )
                 await notify_event(
                     event_type="automation_success",
@@ -419,35 +447,10 @@ async def vip_automation_job() -> None:
             last_vip_time = (
                 cfg.get("perk_automation", {}).get("vip_automation", {}).get("last_vip_time")
             )
-            last_purchase = None
-            if last_vip_time:
-                try:
-                    last_purchase = datetime.fromisoformat(last_vip_time)
-                except Exception:
-                    last_purchase = None
-            now_dt = now
-            time_trigger_ok = True
-            if trigger_type in ("time", "both"):
-                if last_purchase:
-                    next_allowed = last_purchase + timedelta(days=int(trigger_days))
-                    if now_dt < next_allowed:
-                        time_trigger_ok = False
-                else:
-                    # No last purchase: skip until a successful purchase sets the timestamp
-                    time_trigger_ok = False
+            time_trigger_ok, guardrail_reason = _evaluate_time_trigger(
+                last_vip_time, trigger_type, trigger_days, now
+            )
             if not time_trigger_ok:
-                if last_purchase:
-                    next_allowed = last_purchase + timedelta(days=int(trigger_days))
-                    next_allowed_str = next_allowed.isoformat()
-                    guardrail_reason = (
-                        f"Time-based trigger not satisfied: next allowed after {next_allowed_str}"
-                    )
-                else:
-                    guardrail_reason = (
-                        "No previous purchase timestamp found. "
-                        "Please toggle and save the automation to start the timer. "
-                        "(Time-based trigger not satisfied.)"
-                    )
                 log_msg = "[AutoVIP] SKIP: Automated VIP purchase for session '%s' skipped: %s"
                 _logger.info(log_msg, label, guardrail_reason)
                 append_ui_event_log(
@@ -576,7 +579,7 @@ async def vip_automation_job() -> None:
                 _persist_automation_state(
                     label,
                     "vip_automation",
-                    {"last_vip_time": now_dt.isoformat(), "retry": 0},
+                    {"last_vip_time": now.isoformat(), "retry": 0},
                     remove=("cooldown_until", "last_fail_time"),
                 )
                 await notify_event(

--- a/tests/backend/test_automation_time_trigger.py
+++ b/tests/backend/test_automation_time_trigger.py
@@ -1,0 +1,162 @@
+"""Characterisation tests for the automation jobs' time-based trigger.
+
+`upload_credit_automation_job` and `vip_automation_job` each carry their own
+copy of the same time-trigger evaluation — 27 identical lines, per jscpd. These
+tests pin what that logic does today, on both jobs, so a shared implementation
+can be shown to preserve it.
+
+They are characterisation tests: written against the jobs as they stand and
+asserting current behaviour, not a specification of what it ought to be.
+"""
+
+from datetime import UTC, datetime, timedelta, tzinfo
+from typing import Any, Self
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from backend import automation
+
+NOW = datetime(2026, 9, 6, 12, 0, 0, tzinfo=UTC)
+
+
+class _FixedDateTime(datetime):
+    """datetime whose `now` is pinned, so trigger arithmetic is deterministic."""
+
+    @classmethod
+    def now(cls, current_tz: tzinfo | None = None) -> Self:
+        """Return the pinned instant in the requested timezone."""
+        return cls.fromtimestamp(NOW.timestamp(), tz=current_tz or UTC)
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch, cfg: dict[str, Any], points: int = 1_000_000
+) -> list[str]:
+    """Point one automation job at a single stub session and record purchases."""
+    purchases: list[str] = []
+
+    async def _buy(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        purchases.append("bought")
+        return {"success": True}
+
+    monkeypatch.setattr(automation, "list_sessions", lambda: ["seedbox"])
+    monkeypatch.setattr(automation, "load_session", lambda _label: cfg)
+    monkeypatch.setattr(automation, "resolve_proxy_from_session_cfg", lambda _cfg: None)
+    monkeypatch.setattr(automation, "get_status", AsyncMock(return_value={"points": points}))
+    monkeypatch.setattr(automation, "buy_upload_credit", _buy)
+    monkeypatch.setattr(automation, "buy_vip", _buy)
+    monkeypatch.setattr(automation, "save_session", Mock())
+    monkeypatch.setattr(automation, "notify_event", AsyncMock())
+    monkeypatch.setattr(automation, "append_ui_event_log", Mock())
+    monkeypatch.setattr(automation, "datetime", _FixedDateTime)
+    automation.reset_automation_shutdown()
+    return purchases
+
+
+def _upload_cfg(last: str | None, trigger_type: str = "time", days: int = 7) -> dict[str, Any]:
+    """Build a session config with upload-credit automation enabled."""
+    auto: dict[str, Any] = {
+        "enabled": True,
+        "trigger_type": trigger_type,
+        "trigger_days": days,
+        "trigger_point_threshold": 1,
+        "gb": 50,
+    }
+    if last is not None:
+        auto["last_upload_time"] = last
+    return {"mam": {"mam_id": "cookie"}, "perk_automation": {"upload_credit": auto}}
+
+
+def _vip_cfg(last: str | None, trigger_type: str = "time", days: int = 7) -> dict[str, Any]:
+    """Build a session config with VIP automation enabled."""
+    auto: dict[str, Any] = {
+        "enabled": True,
+        "trigger_type": trigger_type,
+        "trigger_days": days,
+        "trigger_point_threshold": 1,
+        "weeks": 4,
+    }
+    if last is not None:
+        auto["last_vip_time"] = last
+    return {"mam": {"mam_id": "cookie"}, "perk_automation": {"vip_automation": auto}}
+
+
+@pytest.mark.parametrize(
+    ("job", "build"),
+    [("upload_credit_automation_job", _upload_cfg), ("vip_automation_job", _vip_cfg)],
+)
+async def test_no_previous_purchase_blocks_a_time_trigger(
+    monkeypatch: pytest.MonkeyPatch, job: str, build: Any
+) -> None:
+    """Absent a timestamp the job waits, rather than treating "never" as "due".
+
+    This is deliberate: the timer starts on a successful purchase, so a session
+    that has never purchased is skipped until one is recorded.
+    """
+    purchases = _install(monkeypatch, build(None))
+
+    await getattr(automation, job)()
+
+    assert purchases == []
+
+
+@pytest.mark.parametrize(
+    ("job", "build"),
+    [("upload_credit_automation_job", _upload_cfg), ("vip_automation_job", _vip_cfg)],
+)
+async def test_a_recent_purchase_blocks_a_time_trigger(
+    monkeypatch: pytest.MonkeyPatch, job: str, build: Any
+) -> None:
+    """Inside the interval, the job does not buy again."""
+    recent = (NOW - timedelta(days=2)).isoformat()
+    purchases = _install(monkeypatch, build(recent, days=7))
+
+    await getattr(automation, job)()
+
+    assert purchases == []
+
+
+@pytest.mark.parametrize(
+    ("job", "build"),
+    [("upload_credit_automation_job", _upload_cfg), ("vip_automation_job", _vip_cfg)],
+)
+async def test_an_elapsed_interval_allows_the_purchase(
+    monkeypatch: pytest.MonkeyPatch, job: str, build: Any
+) -> None:
+    """Once the interval has passed, the purchase proceeds."""
+    stale = (NOW - timedelta(days=30)).isoformat()
+    purchases = _install(monkeypatch, build(stale, days=7))
+
+    await getattr(automation, job)()
+
+    assert purchases == ["bought"]
+
+
+@pytest.mark.parametrize(
+    ("job", "build"),
+    [("upload_credit_automation_job", _upload_cfg), ("vip_automation_job", _vip_cfg)],
+)
+async def test_an_unparseable_timestamp_is_treated_as_no_purchase(
+    monkeypatch: pytest.MonkeyPatch, job: str, build: Any
+) -> None:
+    """A corrupt timestamp falls back to the no-timestamp path rather than raising."""
+    purchases = _install(monkeypatch, build("not-a-timestamp"))
+
+    await getattr(automation, job)()
+
+    assert purchases == []
+
+
+@pytest.mark.parametrize(
+    ("job", "build"),
+    [("upload_credit_automation_job", _upload_cfg), ("vip_automation_job", _vip_cfg)],
+)
+async def test_a_points_trigger_ignores_the_timestamp(
+    monkeypatch: pytest.MonkeyPatch, job: str, build: Any
+) -> None:
+    """With trigger_type "points" the time check is skipped entirely."""
+    purchases = _install(monkeypatch, build(None, trigger_type="points"))
+
+    await getattr(automation, job)()
+
+    assert purchases == ["bought"]


### PR DESCRIPTION
`upload_credit_automation_job` and `vip_automation_job` each carried their
own copy of the same 27 lines: parse the stored timestamp, add the interval,
decide whether the trigger is due, and build the skip message. jscpd matched
them exactly. They now call one `_evaluate_time_trigger`.

**Tests first.** `tests/backend/test_automation_time_trigger.py` is new and
was written and confirmed passing against the previous code, then re-run
unchanged after the extraction. Ten cases, each parametrised over both jobs:
no recorded purchase, a purchase inside the interval, an elapsed interval, an
unparseable timestamp, and a points-only trigger that ignores time entirely.

Negative-controlled rather than assumed. Making the no-timestamp branch
permissive fails four of them; inverting the interval comparison fails four.
So the tests constrain the behaviour they claim to.

The helper is the existing logic, restructured to return early rather than
assign through a flag. The one behavioural equivalence worth naming: the old
code skipped when `now < next_allowed`, so the boundary instant counted as
due; the helper proceeds when `now >= next_allowed`, which is the same
decision at the same instant.

`now_dt` was a local alias for `now` that only existed inside the extracted
block; its two remaining uses now reference `now` directly.

Duplication in the file falls from 18 clones over 221 lines (35.65%) to 17
over 193 (30.98%). The file is three lines longer — the shared helper carries
a docstring the duplicated copies never did — so the gain here is one place
to change this rule, not fewer lines. The remaining clones are inside
`vip_automation_job` and are a separate shape.

Validated: `./scripts/lint.sh` clean on all 16 hooks, backend suite passes,
mypy and pyright clean.