### PR TITLE
refactor(automation): share the guardrail-skip event between both jobs

### DIFF
--- a/backend/automation.py
+++ b/backend/automation.py
@@ -13,6 +13,7 @@ Functions provided:
 - vip_automation_job: automation for VIP purchases.
 """
 
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 import logging
 import threading
@@ -74,6 +75,72 @@ def _persist_automation_state(
 
 
 # --- Automation Scheduler ---
+@dataclass(frozen=True)
+class _PerkJob:
+    """Names the parts of a perk automation job that differ between perks.
+
+    The upload-credit and VIP jobs write the same guardrail-skip event ten
+    times between them, varying only in these fields and the reason text.
+
+    Attributes:
+        purchase_type: Value recorded as `purchase_type` in the event log.
+        state_key: Key under `perk_automation` holding this perk's settings.
+        log_prefix: Prefix used in this job's log lines, e.g. "[AutoUpload]".
+        perk_label: Human-readable perk name used in user-facing messages.
+
+    """
+
+    purchase_type: str
+    state_key: str
+    log_prefix: str
+    perk_label: str
+
+
+_UPLOAD_JOB = _PerkJob("upload_credit", "upload_credit", "[AutoUpload]", "Upload Credit")
+_VIP_JOB = _PerkJob("vip", "vip_automation", "[AutoVIP]", "VIP")
+
+
+def _log_automation_skip(
+    job: _PerkJob,
+    label: str,
+    amount: Any,
+    points: Any,
+    reason: str,
+    now: datetime,
+) -> None:
+    """Record a guardrail-blocked purchase in the log and the UI event log.
+
+    Args:
+        job: Which perk job is skipping.
+        label: Session label.
+        amount: Perk amount that would have been purchased.
+        points: Points held before the skip, for the event details.
+        reason: Guardrail explanation shown to the user.
+        now: Current time, so the event shares the job's clock.
+
+    """
+    _logger.info(
+        "%s SKIP: Automated %s purchase for session '%s' skipped: %s",
+        job.log_prefix,
+        job.perk_label,
+        label,
+        reason,
+    )
+    append_ui_event_log(
+        {
+            "timestamp": now.isoformat(),
+            "label": label,
+            "event_type": "automation",
+            "trigger": "automation",
+            "purchase_type": job.purchase_type,
+            "amount": amount,
+            "details": {"points_before": points},
+            "result": "skipped",
+            "status_message": f"Automated {job.perk_label} purchase skipped: {reason}",
+        }
+    )
+
+
 def _evaluate_time_trigger(
     last_purchase_iso: str | None,
     trigger_type: str,
@@ -194,21 +261,7 @@ async def upload_credit_automation_job() -> None:
             session_min_points = cfg.get("perk_automation", {}).get("min_points")
             if session_min_points is not None and int(points) < int(session_min_points):
                 guardrail_reason = f"Below session minimum points: {points} < {session_min_points}"
-                log_msg = "[AutoUpload] SKIP: Automated Upload Credit purchase for session '%s' skipped: %s"
-                _logger.info(log_msg, label, guardrail_reason)
-                append_ui_event_log(
-                    {
-                        "timestamp": now.isoformat(),
-                        "label": label,
-                        "event_type": "automation",
-                        "trigger": "automation",
-                        "purchase_type": "upload_credit",
-                        "amount": gb_amount,
-                        "details": {"points_before": points},
-                        "result": "skipped",
-                        "status_message": f"Automated Upload Credit purchase skipped: {guardrail_reason}",
-                    }
-                )
+                _log_automation_skip(_UPLOAD_JOB, label, gb_amount, points, guardrail_reason, now)
                 # Do not check any automation-level guardrails if session minimum is not met
                 continue
             # --- Enforce minimum points guardrail (prevent spend below minimum) ---
@@ -223,20 +276,8 @@ async def upload_credit_automation_job() -> None:
                         f"{points} - {purchase_cost} = {int(points) - purchase_cost} "
                         f"< {session_min_points}"
                     )
-                    log_msg = "[AutoUpload] SKIP: Automated Upload Credit purchase for session '%s' skipped: %s"
-                    _logger.info(log_msg, label, guardrail_reason)
-                    append_ui_event_log(
-                        {
-                            "timestamp": now.isoformat(),
-                            "label": label,
-                            "event_type": "automation",
-                            "trigger": "automation",
-                            "purchase_type": "upload_credit",
-                            "amount": gb_amount,
-                            "details": {"points_before": points},
-                            "result": "skipped",
-                            "status_message": f"Automated Upload Credit purchase skipped: {guardrail_reason}",
-                        }
+                    _log_automation_skip(
+                        _UPLOAD_JOB, label, gb_amount, points, guardrail_reason, now
                     )
                     continue
             # --- Time-based trigger enforcement ---
@@ -247,42 +288,14 @@ async def upload_credit_automation_job() -> None:
                 last_upload_time, trigger_type, trigger_days, now
             )
             if not time_trigger_ok:
-                log_msg = "[AutoUpload] SKIP: Automated Upload Credit purchase for session '%s' skipped: %s"
-                _logger.info(log_msg, label, guardrail_reason)
-                append_ui_event_log(
-                    {
-                        "timestamp": now.isoformat(),
-                        "label": label,
-                        "event_type": "automation",
-                        "trigger": "automation",
-                        "purchase_type": "upload_credit",
-                        "amount": gb_amount,
-                        "details": {"points_before": points},
-                        "result": "skipped",
-                        "status_message": f"Automated Upload Credit purchase skipped: {guardrail_reason}",
-                    }
-                )
+                _log_automation_skip(_UPLOAD_JOB, label, gb_amount, points, guardrail_reason, now)
                 continue
             # --- Automation-level point threshold guardrail ---
             if trigger_type in ("points", "both") and int(points) < int(trigger_point_threshold):
                 guardrail_reason = (
                     f"Below automation point threshold: {points} < {trigger_point_threshold}"
                 )
-                log_msg = "[AutoUpload] SKIP: Automated Upload Credit purchase for session '%s' skipped: %s"
-                _logger.info(log_msg, label, guardrail_reason)
-                append_ui_event_log(
-                    {
-                        "timestamp": now.isoformat(),
-                        "label": label,
-                        "event_type": "automation",
-                        "trigger": "automation",
-                        "purchase_type": "upload_credit",
-                        "amount": gb_amount,
-                        "details": {"points_before": points},
-                        "result": "skipped",
-                        "status_message": f"Automated Upload Credit purchase skipped: {guardrail_reason}",
-                    }
-                )
+                _log_automation_skip(_UPLOAD_JOB, label, gb_amount, points, guardrail_reason, now)
                 continue
             # All guardrails passed, attempt purchase
             result = await buy_upload_credit(gb_amount, mam_id=mam_id, proxy_cfg=proxy_cfg)
@@ -383,21 +396,7 @@ async def vip_automation_job() -> None:
             session_min_points = cfg.get("perk_automation", {}).get("min_points")
             if session_min_points is not None and int(points) < int(session_min_points):
                 guardrail_reason = f"Below session minimum points: {points} < {session_min_points}"
-                log_msg = "[AutoVIP] SKIP: Automated VIP purchase for session '%s' skipped: %s"
-                _logger.info(log_msg, label, guardrail_reason)
-                append_ui_event_log(
-                    {
-                        "timestamp": now.isoformat(),
-                        "label": label,
-                        "event_type": "automation",
-                        "trigger": "automation",
-                        "purchase_type": "vip",
-                        "amount": weeks,
-                        "details": {"points_before": points},
-                        "result": "skipped",
-                        "status_message": f"Automated VIP purchase skipped: {guardrail_reason}",
-                    }
-                )
+                _log_automation_skip(_VIP_JOB, label, weeks, points, guardrail_reason, now)
                 # Reset retry state if not eligible
                 if "retry" in automation:
                     _persist_automation_state(
@@ -423,21 +422,7 @@ async def vip_automation_job() -> None:
                         f"{points} - {purchase_cost} = {int(points) - purchase_cost} "
                         f"< {session_min_points}"
                     )
-                    log_msg = "[AutoVIP] SKIP: Automated VIP purchase for session '%s' skipped: %s"
-                    _logger.info(log_msg, label, guardrail_reason)
-                    append_ui_event_log(
-                        {
-                            "timestamp": now.isoformat(),
-                            "label": label,
-                            "event_type": "automation",
-                            "trigger": "automation",
-                            "purchase_type": "vip",
-                            "amount": weeks,
-                            "details": {"points_before": points},
-                            "result": "skipped",
-                            "status_message": f"Automated VIP purchase skipped: {guardrail_reason}",
-                        }
-                    )
+                    _log_automation_skip(_VIP_JOB, label, weeks, points, guardrail_reason, now)
                     if "retry" in automation:
                         _persist_automation_state(
                             label, "vip_automation", {}, remove=("retry", "cooldown_until")
@@ -451,21 +436,7 @@ async def vip_automation_job() -> None:
                 last_vip_time, trigger_type, trigger_days, now
             )
             if not time_trigger_ok:
-                log_msg = "[AutoVIP] SKIP: Automated VIP purchase for session '%s' skipped: %s"
-                _logger.info(log_msg, label, guardrail_reason)
-                append_ui_event_log(
-                    {
-                        "timestamp": now.isoformat(),
-                        "label": label,
-                        "event_type": "automation",
-                        "trigger": "automation",
-                        "purchase_type": "vip",
-                        "amount": weeks,
-                        "details": {"points_before": points},
-                        "result": "skipped",
-                        "status_message": f"Automated VIP purchase skipped: {guardrail_reason}",
-                    }
-                )
+                _log_automation_skip(_VIP_JOB, label, weeks, points, guardrail_reason, now)
                 # Reset retry state if not eligible
                 if "retry" in automation:
                     _persist_automation_state(
@@ -477,21 +448,7 @@ async def vip_automation_job() -> None:
                 guardrail_reason = (
                     f"Below automation point threshold: {points} < {trigger_point_threshold}"
                 )
-                log_msg = "[AutoVIP] SKIP: Automated VIP purchase for session '%s' skipped: %s"
-                _logger.info(log_msg, label, guardrail_reason)
-                append_ui_event_log(
-                    {
-                        "timestamp": now.isoformat(),
-                        "label": label,
-                        "event_type": "automation",
-                        "trigger": "automation",
-                        "purchase_type": "vip",
-                        "amount": weeks,
-                        "details": {"points_before": points},
-                        "result": "skipped",
-                        "status_message": f"Automated VIP purchase skipped: {guardrail_reason}",
-                    }
-                )
+                _log_automation_skip(_VIP_JOB, label, weeks, points, guardrail_reason, now)
                 # Reset retry state if not eligible
                 if "retry" in automation:
                     _persist_automation_state(

--- a/tests/backend/test_automation_time_trigger.py
+++ b/tests/backend/test_automation_time_trigger.py
@@ -30,9 +30,15 @@ class _FixedDateTime(datetime):
 
 
 def _install(
-    monkeypatch: pytest.MonkeyPatch, cfg: dict[str, Any], points: int = 1_000_000
+    monkeypatch: pytest.MonkeyPatch,
+    cfg: dict[str, Any],
+    points: int = 1_000_000,
+    events: list[dict[str, Any]] | None = None,
 ) -> list[str]:
-    """Point one automation job at a single stub session and record purchases."""
+    """Point one automation job at a single stub session and record purchases.
+
+    Pass `events` to also capture every UI event-log payload the job writes.
+    """
     purchases: list[str] = []
 
     async def _buy(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
@@ -47,7 +53,11 @@ def _install(
     monkeypatch.setattr(automation, "buy_vip", _buy)
     monkeypatch.setattr(automation, "save_session", Mock())
     monkeypatch.setattr(automation, "notify_event", AsyncMock())
-    monkeypatch.setattr(automation, "append_ui_event_log", Mock())
+    monkeypatch.setattr(
+        automation,
+        "append_ui_event_log",
+        events.append if events is not None else Mock(),
+    )
     monkeypatch.setattr(automation, "datetime", _FixedDateTime)
     automation.reset_automation_shutdown()
     return purchases
@@ -160,3 +170,39 @@ async def test_a_points_trigger_ignores_the_timestamp(
     await getattr(automation, job)()
 
     assert purchases == ["bought"]
+
+
+@pytest.mark.parametrize(
+    ("job", "build", "purchase_type", "prefix"),
+    [
+        ("upload_credit_automation_job", _upload_cfg, "upload_credit", "Upload Credit"),
+        ("vip_automation_job", _vip_cfg, "vip", "VIP"),
+    ],
+)
+async def test_a_time_skip_writes_the_expected_event(
+    monkeypatch: pytest.MonkeyPatch, job: str, build: Any, purchase_type: str, prefix: str
+) -> None:
+    """Pin the skip event's shape, not just that the purchase did not happen.
+
+    Ten of these blocks are written out longhand across the two jobs and are
+    identical bar the reason, so the payload is what a shared implementation
+    has to reproduce.
+    """
+    events: list[dict[str, Any]] = []
+    recent = (NOW - timedelta(days=2)).isoformat()
+    purchases = _install(monkeypatch, build(recent, days=7), events=events)
+
+    await getattr(automation, job)()
+
+    assert purchases == []
+    skipped = [e for e in events if e.get("result") == "skipped"]
+    assert len(skipped) == 1
+    event = skipped[0]
+    assert event["label"] == "seedbox"
+    assert event["event_type"] == "automation"
+    assert event["trigger"] == "automation"
+    assert event["purchase_type"] == purchase_type
+    assert event["details"] == {"points_before": 1_000_000}
+    assert event["status_message"].startswith(f"Automated {prefix} purchase skipped: ")
+    assert "Time-based trigger not satisfied" in event["status_message"]
+    assert event["timestamp"] == NOW.isoformat()


### PR DESCRIPTION
Eight guardrail-skip blocks were written out longhand across the two
automation jobs — four each — differing only in the perk's name, its amount
field and the reason text. Each was fifteen lines of log line plus
`append_ui_event_log` payload. They now call `_log_automation_skip`,
parameterised by a `_PerkJob` describing what differs, in the same shape as
the `ServarrService` descriptor added in #115.

**The payload was pinned before it moved.** The characterisation tests from
#126 asserted only that a skip happened, not what it recorded, so a shared
writer could have altered the event unnoticed. Two tests were added first —
one per job — asserting the event's label, type, trigger, purchase type,
details, timestamp and status message. They pass unchanged after the
extraction.

**Two skip blocks are deliberately left alone.** VIP's cooldown and retry
paths write `"Cooldown active until ..."` and `"Waiting between retries
(retry N)"` rather than the shared `"Automated {perk} purchase skipped:
{reason}"`. Folding them in would need a status-message override, which
would weaken the helper's contract for the sake of two callers that
genuinely say something else.

Measured on the file: 17 clones over 193 lines (30.98%) falls to 10 over 79
(13.62%), and it is 43 lines shorter. Unlike the time-trigger extraction in
#126, this one pays in both duplication and size.

Validated: `./scripts/lint.sh` clean on all 16 hooks, backend suite passes,
mypy and pyright clean.